### PR TITLE
feat: remove score-based default sorting from query summary tables

### DIFF
--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryGeneAlterations.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryGeneAlterations.vue
@@ -7,7 +7,7 @@
 
 <script lang="ts">
 import {
-    defineComponent, onUnmounted, ref, watch,
+    defineComponent, onUnmounted, ref,
 } from 'vue';
 import type { BTableSortBy, TableFieldRaw } from 'bootstrap-vue-next';
 import { BTable } from 'bootstrap-vue-next';
@@ -47,9 +47,7 @@ export default defineComponent({
         const total = ref(0);
         const offset = ref(0);
         const limit = ref(50);
-        const defaultSort: BTableSortBy[] = [{ key: 'score', order: 'desc' }];
-        const sortBy = ref<BTableSortBy[]>([...defaultSort]);
-        const sortLabelMap: Record<string, string> = { score: 'Relevanz' };
+        const sortBy = ref<BTableSortBy[]>([]);
 
         const fields : TableFieldRaw[] = [
             {
@@ -137,24 +135,8 @@ export default defineComponent({
             removeFiltersHandler();
         });
 
-        watch(sortBy, (value) => {
-            const hasActive = value.some((s) => s.order);
-            if (!hasActive) {
-                sortBy.value = [...defaultSort];
-                return;
-            }
-
-            const hasNonScore = value.some((s) => s.key !== 'score' && s.order);
-            if (hasNonScore) {
-                const filtered = value.filter((s) => s.key !== 'score');
-                if (filtered.length !== value.length) {
-                    sortBy.value = filtered;
-                }
-            }
-        });
-
         const resetSort = () => {
-            sortBy.value = [...defaultSort];
+            sortBy.value = [];
             tableRef.value?.refresh();
         };
 
@@ -165,7 +147,6 @@ export default defineComponent({
             offset,
             limit,
             sortBy,
-            sortLabelMap,
             fields,
             provider,
             load,
@@ -186,7 +167,6 @@ export default defineComponent({
     <DSortIndicator
         :sort-by="sortBy"
         :fields="fields"
-        :label-map="sortLabelMap"
         @reset="resetSort"
     />
 

--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryTherapyResponses.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryTherapyResponses.vue
@@ -7,7 +7,7 @@
 
 <script lang="ts">
 import {
-    defineComponent, onUnmounted, ref, watch,
+    defineComponent, onUnmounted, ref,
 } from 'vue';
 import type { BTableSortBy, TableFieldRaw } from 'bootstrap-vue-next';
 import { BTable } from 'bootstrap-vue-next';
@@ -49,9 +49,7 @@ export default defineComponent({
         const total = ref(0);
         const offset = ref(0);
         const limit = ref(50);
-        const defaultSort: BTableSortBy[] = [{ key: 'score', order: 'desc' }];
-        const sortBy = ref<BTableSortBy[]>([...defaultSort]);
-        const sortLabelMap: Record<string, string> = { score: 'Relevanz' };
+        const sortBy = ref<BTableSortBy[]>([]);
 
         const fields : TableFieldRaw[] = [
             {
@@ -145,24 +143,8 @@ export default defineComponent({
             removeFiltersHandler();
         });
 
-        watch(sortBy, (value) => {
-            const hasActive = value.some((s) => s.order);
-            if (!hasActive) {
-                sortBy.value = [...defaultSort];
-                return;
-            }
-
-            const hasNonScore = value.some((s) => s.key !== 'score' && s.order);
-            if (hasNonScore) {
-                const filtered = value.filter((s) => s.key !== 'score');
-                if (filtered.length !== value.length) {
-                    sortBy.value = filtered;
-                }
-            }
-        });
-
         const resetSort = () => {
-            sortBy.value = [...defaultSort];
+            sortBy.value = [];
             tableRef.value?.refresh();
         };
 
@@ -173,7 +155,6 @@ export default defineComponent({
             offset,
             limit,
             sortBy,
-            sortLabelMap,
             fields,
             provider,
             load,
@@ -194,7 +175,6 @@ export default defineComponent({
     <DSortIndicator
         :sort-by="sortBy"
         :fields="fields"
-        :label-map="sortLabelMap"
         @reset="resetSort"
     />
 


### PR DESCRIPTION
closes #1188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Query summary sections for Gene Alterations and Therapy Responses no longer apply a default sort on load.
  * The sort reset action now clears all active sorting rather than restoring a predefined default.
  * Custom sort labels have been removed from the sort indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->