### PR TITLE
feat: unified query filter box controls with active indicator and reset

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -66,3 +66,11 @@ Scopes typically match package names: `core`, `portal`, `mtb`, `rd`, `admin`, `k
 - Respect separation of concerns: shared logic → `core`, module registration → `kit`, domain UI → feature modules, app shell → `portal`
 - Prefer editing existing files over creating new ones
 - Keep changes minimal and focused on the task at hand
+
+## Keep MTB and RD Modules in Sync
+
+The `mtb` and `rd` feature modules expose parallel UI patterns (filters, query pages, summary views). When changing one, check the other for the equivalent component and mirror the change so the two modules stay consistent in behavior and appearance.
+
+- Naming parallels: `MQuery*` (mtb) ↔ `RQuery*` (rd), both consuming shared components from `core` (e.g. `DQueryFilterBox`).
+- Before finishing a task touching one module, grep the other for the matching component (`MQueryDiagnosisFilter` → `RQueryDiagnosisFilter`, etc.) and apply equivalent changes.
+- If a pattern only makes sense in one module, document why in a comment or commit message.

--- a/packages/core/src/components/core/query/QueryFilterBox.vue
+++ b/packages/core/src/components/core/query/QueryFilterBox.vue
@@ -15,8 +15,13 @@ export default defineComponent({
             type: String,
             required: true,
         },
+        active: {
+            type: Boolean,
+            default: false,
+        },
     },
-    setup(props) {
+    emits: ['reset'],
+    setup(props, { emit }) {
         const store = useQueryFilterStore();
         const storeRefs = storeToRefs(store);
 
@@ -26,9 +31,14 @@ export default defineComponent({
             store.setActive(props.name);
         };
 
+        const reset = () => {
+            emit('reset');
+        };
+
         return {
             extended,
             toggleExtended,
+            reset,
         };
     },
 });
@@ -36,15 +46,29 @@ export default defineComponent({
 <template>
     <div class="entity-card">
         <div class="d-flex flex-column gap-2">
-            <div class="d-flex flex-row">
+            <div class="d-flex flex-row align-items-center">
                 <div>
                     <h6 class="text-muted mb-0">
                         <slot name="title">
                             Filter
                         </slot>
+                        <i
+                            v-if="active"
+                            class="fa fa-circle text-success ms-1"
+                            style="font-size: 0.5em; vertical-align: middle;"
+                            aria-label="Filter aktiv"
+                        />
                     </h6>
                 </div>
-                <div class="ms-auto">
+                <div class="ms-auto d-flex gap-1">
+                    <button
+                        v-if="active"
+                        class="btn btn-secondary btn-xs"
+                        title="Filter zurücksetzen"
+                        @click.prevent="reset"
+                    >
+                        <i class="fa fa-rotate-left" />
+                    </button>
                     <button
                         class="btn btn-dark btn-xs"
                         :disabled="extended"

--- a/packages/core/src/components/core/query/QueryFilterBox.vue
+++ b/packages/core/src/components/core/query/QueryFilterBox.vue
@@ -56,23 +56,29 @@ export default defineComponent({
                             v-if="active"
                             class="fa fa-circle text-success ms-1"
                             style="font-size: 0.5em; vertical-align: middle;"
+                            role="img"
                             aria-label="Filter aktiv"
                         />
                     </h6>
                 </div>
                 <div class="ms-auto d-flex gap-1">
                     <button
+                        type="button"
                         class="btn btn-xs"
                         :class="active ? 'btn-danger' : 'btn-secondary'"
                         :disabled="!active"
                         title="Filter zurücksetzen"
+                        aria-label="Filter zurücksetzen"
                         @click.prevent="reset"
                     >
                         <i class="fa fa-rotate-left" />
                     </button>
                     <button
+                        type="button"
                         class="btn btn-dark btn-xs"
                         :disabled="extended"
+                        :title="extended ? 'Filter ausgeklappt' : 'Filter ausklappen'"
+                        :aria-label="extended ? 'Filter ausgeklappt' : 'Filter ausklappen'"
                         @click.prevent="toggleExtended"
                     >
                         <i :class="{'fa fa-chevron-down': !extended, 'fa fa-chevron-up': extended}" />

--- a/packages/core/src/components/core/query/QueryFilterBox.vue
+++ b/packages/core/src/components/core/query/QueryFilterBox.vue
@@ -62,8 +62,9 @@ export default defineComponent({
                 </div>
                 <div class="ms-auto d-flex gap-1">
                     <button
-                        v-if="active"
-                        class="btn btn-secondary btn-xs"
+                        class="btn btn-xs"
+                        :class="active ? 'btn-danger' : 'btn-secondary'"
+                        :disabled="!active"
                         title="Filter zurücksetzen"
                         @click.prevent="reset"
                     >

--- a/packages/core/src/components/core/query/QueryFilterContainer.vue
+++ b/packages/core/src/components/core/query/QueryFilterContainer.vue
@@ -5,6 +5,7 @@
   - view the LICENSE file that was distributed with this source code.
   -->
 <script lang="ts">
+import { storeToRefs } from '@authup/client-web-kit';
 import { defineComponent } from 'vue';
 import { useQueryFilterStore } from '../../../stores';
 
@@ -12,6 +13,7 @@ export default defineComponent({
     emits: ['submitted'],
     setup(_props, { emit }) {
         const store = useQueryFilterStore();
+        const { dirty } = storeToRefs(store);
 
         const submit = () => {
             store.commit();
@@ -19,7 +21,7 @@ export default defineComponent({
             emit('submitted');
         };
 
-        return { submit };
+        return { submit, dirty };
     },
 });
 </script>
@@ -30,7 +32,9 @@ export default defineComponent({
         <div class="entity-card">
             <button
                 type="button"
-                class="btn btn-sm btn-primary btn-block"
+                class="btn btn-sm btn-block"
+                :class="dirty ? 'btn-primary' : 'btn-secondary'"
+                :disabled="!dirty"
                 @click.prevent="submit"
             >
                 Anwenden

--- a/packages/core/src/components/core/query/QueryPatientFilters.vue
+++ b/packages/core/src/components/core/query/QueryPatientFilters.vue
@@ -1,6 +1,11 @@
 <script lang="ts">
 import { VCFormRangeMultiSlider } from '@vuecs/form-controls';
-import { defineComponent, onUnmounted, ref } from 'vue';
+import { 
+    computed, 
+    defineComponent, 
+    onUnmounted, 
+    ref, 
+} from 'vue';
 import { QueryFilterURLKey } from '../../../constants';
 import { injectHTTPClient } from '../../../core';
 import type { Coding, PatientFilter } from '../../../domains';
@@ -276,9 +281,19 @@ export default defineComponent({
             emit('submit');
         };
 
+        const active = computed(() => (
+            store.getItems(QueryFilterURLKey.GENDER).length > 0 ||
+            store.getItems(QueryFilterURLKey.VITAL_STATUS).length > 0 ||
+            store.getItems(QueryFilterURLKey.SITE).length > 0 ||
+            store.getItems(QueryFilterURLKey.AGE_MIN).length > 0 ||
+            store.getItems(QueryFilterURLKey.AGE_MAX).length > 0
+        ));
+
         return {
             available,
             availableInitialized,
+
+            active,
 
             age,
             gender,
@@ -297,7 +312,11 @@ export default defineComponent({
 });
 </script>
 <template>
-    <QueryFilterBox :name="'patient'">
+    <QueryFilterBox
+        :name="'patient'"
+        :active="active"
+        @reset="reset"
+    >
         <template #title>
             <i class="fa fa-user-injured" /> Patient
         </template>
@@ -383,17 +402,6 @@ export default defineComponent({
                         :max="age.max"
                         @change="handleAgeRangeChanged"
                     />
-                </div>
-            </div>
-            <div class="row">
-                <div>
-                    <button
-                        type="button"
-                        class="btn btn-xs btn-secondary btn-block"
-                        @click.prevent="reset"
-                    >
-                        Zurücksetzen
-                    </button>
                 </div>
             </div>
         </template>

--- a/packages/core/src/stores/query-filter/module.ts
+++ b/packages/core/src/stores/query-filter/module.ts
@@ -57,11 +57,19 @@ export function createQueryFilterStore(ctx: StoreCreateOptions) {
         items.value[key].push(input);
     };
 
+    const dirty = ref<boolean>(false);
+
     const setItems = (key: string, input: QueryFilterItem[]) => {
+        const previous = items.value[key] || [];
+
         items.value[key] = [];
 
         for (const item of input) {
             addItem(key, item);
+        }
+
+        if (!isEqual(previous, input)) {
+            dirty.value = true;
         }
 
         ctx.queryEventBus.emit(QueryEventBusEventName.FILTER_UPDATED, key);
@@ -72,6 +80,7 @@ export function createQueryFilterStore(ctx: StoreCreateOptions) {
     // ----------------------------------------------------------------
 
     const commit = () => {
+        dirty.value = false;
         ctx.queryEventBus.emit(QueryEventBusEventName.FILTERS_COMMITED);
     };
 
@@ -92,6 +101,8 @@ export function createQueryFilterStore(ctx: StoreCreateOptions) {
 
         setItems,
         getItems,
+
+        dirty,
 
         commit,
     };

--- a/packages/mtb/src/runtime/components/core/query-filter/MQueryDiagnosisFilter.vue
+++ b/packages/mtb/src/runtime/components/core/query-filter/MQueryDiagnosisFilter.vue
@@ -91,12 +91,14 @@ export default defineComponent({
         };
 
         const init = () => {
+            const availableCodes = itemsAvailable.value.map((el) => el.code);
             const storeItems = store.getItems(QueryFilterURLKey.DIAGNOSIS_CODE)
                 .filter((el) => isCoding(el))
-                .map((el) => el.code);
+                .map((el) => el.code)
+                .filter((code) => availableCodes.includes(code));
 
             if (storeItems.length === 0) {
-                items.value = itemsAvailable.value.map((el) => el.code);
+                items.value = availableCodes;
 
                 return;
             }

--- a/packages/mtb/src/runtime/components/core/query-filter/MQueryDiagnosisFilter.vue
+++ b/packages/mtb/src/runtime/components/core/query-filter/MQueryDiagnosisFilter.vue
@@ -145,14 +145,8 @@ export default defineComponent({
             listenForFilterUpdates.value = true;
         };
 
-        const selectAll = () => {
+        const reset = () => {
             items.value = itemsAvailable.value.map((el) => el.code);
-
-            setFilter();
-        };
-
-        const unselectAll = () => {
-            items.value = [];
 
             setFilter();
         };
@@ -165,13 +159,16 @@ export default defineComponent({
             setFilter();
         };
 
+        const active = computed(() => store.getItems(QueryFilterURLKey.DIAGNOSIS_CODE).length > 0);
+
         return {
             items,
             itemsAvailableInitialized,
 
+            active,
+
             handleChanged,
-            selectAll,
-            unselectAll,
+            reset,
 
             availableSubset,
             total,
@@ -183,36 +180,17 @@ export default defineComponent({
 });
 </script>
 <template>
-    <DQueryFilterBox :name="'diagnosis'">
+    <DQueryFilterBox
+        :name="'diagnosis'"
+        :active="active"
+        @reset="reset"
+    >
         <template #title>
             <i class="fa fa-stethoscope" /> Diagnose
         </template>
         <template #default>
             <div class=" flex-column gap-1 d-flex">
                 <div class="d-flex flex-column gap-2">
-                    <div class="d-flex flex-row">
-                        <div>
-                            <button
-                                :disabled="!itemsAvailableInitialized"
-                                type="button"
-                                class="btn btn-xs btn-dark"
-                                @click.prevent="selectAll"
-                            >
-                                Alle auswählen
-                            </button>
-                        </div>
-                        <div class="ms-auto">
-                            <button
-                                :disabled="!itemsAvailableInitialized"
-                                type="button"
-                                class="btn btn-xs btn-dark"
-                                @click.prevent="unselectAll"
-                            >
-                                Alle abwählen
-                            </button>
-                        </div>
-                    </div>
-
                     <div>
                         <template
                             v-for="item in availableSubset"

--- a/packages/mtb/src/runtime/components/core/query-filter/MQueryMedicationFilter.vue
+++ b/packages/mtb/src/runtime/components/core/query-filter/MQueryMedicationFilter.vue
@@ -173,14 +173,8 @@ export default defineComponent({
             listenForFilterUpdates.value = true;
         };
 
-        const selectAll = () => {
+        const reset = () => {
             items.value = itemsAvailable.value.map((el) => el.id);
-
-            setFilter();
-        };
-
-        const unselectAll = () => {
-            items.value = [];
 
             setFilter();
         };
@@ -193,13 +187,16 @@ export default defineComponent({
             setFilter();
         };
 
+        const active = computed(() => store.getItems(storeKey.value).length > 0);
+
         return {
             items,
             itemsAvailableInitialized,
 
+            active,
+
             handleChanged,
-            selectAll,
-            unselectAll,
+            reset,
 
             availableSubset,
             total,
@@ -211,7 +208,11 @@ export default defineComponent({
 });
 </script>
 <template>
-    <DQueryFilterBox :name="type">
+    <DQueryFilterBox
+        :name="type"
+        :active="active"
+        @reset="reset"
+    >
         <template #title>
             <template v-if="type === 'recommended'">
                 <i class="fa fa-pills" /> Therapien: Empfohlen
@@ -223,29 +224,6 @@ export default defineComponent({
         <template #default>
             <div class=" flex-column gap-1 d-flex">
                 <div class="d-flex flex-column gap-2">
-                    <div class="d-flex flex-row">
-                        <div>
-                            <button
-                                :disabled="!itemsAvailableInitialized"
-                                type="button"
-                                class="btn btn-xs btn-dark"
-                                @click.prevent="selectAll"
-                            >
-                                Alle auswählen
-                            </button>
-                        </div>
-                        <div class="ms-auto">
-                            <button
-                                :disabled="!itemsAvailableInitialized"
-                                type="button"
-                                class="btn btn-xs btn-dark"
-                                @click.prevent="unselectAll"
-                            >
-                                Alle abwählen
-                            </button>
-                        </div>
-                    </div>
-
                     <div>
                         <template
                             v-for="item in availableSubset"

--- a/packages/mtb/src/runtime/components/core/query-filter/MQueryMedicationFilter.vue
+++ b/packages/mtb/src/runtime/components/core/query-filter/MQueryMedicationFilter.vue
@@ -112,12 +112,14 @@ export default defineComponent({
 
         // todo: refactor
         const init = () => {
+            const availableIds = itemsAvailable.value.map((el) => el.id);
             const storeItems = store.getItems(storeKey.value)
                 .filter((el) => isCodingGroup(el))
-                .map((el) => el.id);
+                .map((el) => el.id)
+                .filter((id) => availableIds.includes(id));
 
             if (storeItems.length === 0) {
-                items.value = itemsAvailable.value.map((el) => el.id);
+                items.value = availableIds;
 
                 return;
             }

--- a/packages/rd/src/runtime/components/core/RQueryDiagnosisFilter.vue
+++ b/packages/rd/src/runtime/components/core/RQueryDiagnosisFilter.vue
@@ -1,11 +1,13 @@
 <script lang="ts">
 import {
-    defineComponent, 
+    computed,
+    defineComponent,
     ref,
 } from 'vue';
 import {
-    type Coding, 
-    DQueryFilterBox, 
+    type Coding,
+    DQueryFilterBox,
+    isCoding,
     useQueryFilterStore,
 } from '@dnpm-dip/core';
 import { QueryURLFilterKey } from '../../constants';
@@ -51,9 +53,24 @@ export default defineComponent({
             }
         };
 
+        const init = () => {
+            const storeItems = store.getItems(QueryURLFilterKey.DIAGNOSIS_CATEGORY)
+                .filter((el) => isCoding(el))
+                .map((el) => el.code);
+
+            if (storeItems.length === 0) {
+                if (available.value.category) {
+                    category.value = available.value.category.map((el) => el.code);
+                }
+                return;
+            }
+
+            category.value = storeItems;
+        };
+
         Promise.resolve()
             .then(() => load())
-            .then(() => reset());
+            .then(() => init());
 
         const handleChanged = () => {
             if (!available.value.category) {
@@ -77,11 +94,15 @@ export default defineComponent({
             store.setItems(QueryURLFilterKey.DIAGNOSIS_CATEGORY, data);
         };
 
+        const active = computed(() => store.getItems(QueryURLFilterKey.DIAGNOSIS_CATEGORY).length > 0);
+
         return {
             available,
             availableInitialized,
 
             category,
+
+            active,
 
             handleChanged,
 
@@ -91,7 +112,11 @@ export default defineComponent({
 });
 </script>
 <template>
-    <DQueryFilterBox :name="'diagnosis'">
+    <DQueryFilterBox
+        :name="'diagnosis'"
+        :active="active"
+        @reset="reset"
+    >
         <template #title>
             <i class="fa fa-stethoscope" /> Diagnose
         </template>
@@ -117,19 +142,6 @@ export default defineComponent({
                             />
                         </div>
                     </template>
-                </div>
-            </div>
-
-            <div class="row">
-                <div>
-                    <button
-                        :disabled="!availableInitialized"
-                        type="button"
-                        class="btn btn-xs btn-secondary btn-block"
-                        @click.prevent="reset"
-                    >
-                        Zurücksetzen
-                    </button>
                 </div>
             </div>
         </template>

--- a/packages/rd/src/runtime/components/core/RQueryDiagnosisFilter.vue
+++ b/packages/rd/src/runtime/components/core/RQueryDiagnosisFilter.vue
@@ -49,19 +49,19 @@ export default defineComponent({
         const reset = () => {
             if (available.value.category) {
                 category.value = available.value.category.map((el) => el.code);
-                store.setItems(QueryURLFilterKey.DIAGNOSIS_CATEGORY, []);
             }
+            store.setItems(QueryURLFilterKey.DIAGNOSIS_CATEGORY, []);
         };
 
         const init = () => {
+            const availableCodes = (available.value.category || []).map((el) => el.code);
             const storeItems = store.getItems(QueryURLFilterKey.DIAGNOSIS_CATEGORY)
                 .filter((el) => isCoding(el))
-                .map((el) => el.code);
+                .map((el) => el.code)
+                .filter((code) => availableCodes.includes(code));
 
             if (storeItems.length === 0) {
-                if (available.value.category) {
-                    category.value = available.value.category.map((el) => el.code);
-                }
+                category.value = availableCodes;
                 return;
             }
 

--- a/packages/rd/src/runtime/components/core/RQueryHPOFilter.vue
+++ b/packages/rd/src/runtime/components/core/RQueryHPOFilter.vue
@@ -1,9 +1,15 @@
 <script lang="ts">
 import {
-    defineComponent, 
+    computed,
+    defineComponent,
     ref,
 } from 'vue';
-import { type Coding, DQueryFilterBox, useQueryFilterStore } from '@dnpm-dip/core';
+import {
+    type Coding,
+    DQueryFilterBox,
+    isCoding,
+    useQueryFilterStore,
+} from '@dnpm-dip/core';
 import { QueryURLFilterKey } from '../../constants';
 import { injectHTTPClient } from '../../core';
 import type { QueryHpoFilter } from '../../domains';
@@ -46,9 +52,24 @@ export default defineComponent({
             }
         };
 
+        const init = () => {
+            const storeItems = store.getItems(QueryURLFilterKey.HPO_VALUE)
+                .filter((el) => isCoding(el))
+                .map((el) => el.code);
+
+            if (storeItems.length === 0) {
+                if (available.value.value) {
+                    items.value = available.value.value.map((el) => el.code);
+                }
+                return;
+            }
+
+            items.value = storeItems;
+        };
+
         Promise.resolve()
             .then(() => load())
-            .then(() => reset());
+            .then(() => init());
 
         const handleChanged = () => {
             if (!available.value.value) {
@@ -72,11 +93,15 @@ export default defineComponent({
             store.setItems(QueryURLFilterKey.HPO_VALUE, data);
         };
 
+        const active = computed(() => store.getItems(QueryURLFilterKey.HPO_VALUE).length > 0);
+
         return {
             available,
             availableInitialized,
 
             items,
+
+            active,
 
             handleChanged,
 
@@ -86,7 +111,11 @@ export default defineComponent({
 });
 </script>
 <template>
-    <DQueryFilterBox :name="'hpo'">
+    <DQueryFilterBox
+        :name="'hpo'"
+        :active="active"
+        @reset="reset"
+    >
         <template #title>
             <i class="fa fa-dna" /> HPO
         </template>
@@ -112,19 +141,6 @@ export default defineComponent({
                             />
                         </div>
                     </template>
-                </div>
-            </div>
-
-            <div class="row">
-                <div>
-                    <button
-                        :disabled="!availableInitialized"
-                        type="button"
-                        class="btn btn-xs btn-secondary btn-block"
-                        @click.prevent="reset"
-                    >
-                        Zurücksetzen
-                    </button>
                 </div>
             </div>
         </template>

--- a/packages/rd/src/runtime/components/core/RQueryHPOFilter.vue
+++ b/packages/rd/src/runtime/components/core/RQueryHPOFilter.vue
@@ -48,19 +48,19 @@ export default defineComponent({
         const reset = () => {
             if (available.value.value) {
                 items.value = available.value.value.map((el) => el.code);
-                store.setItems(QueryURLFilterKey.HPO_VALUE, []);
             }
+            store.setItems(QueryURLFilterKey.HPO_VALUE, []);
         };
 
         const init = () => {
+            const availableCodes = (available.value.value || []).map((el) => el.code);
             const storeItems = store.getItems(QueryURLFilterKey.HPO_VALUE)
                 .filter((el) => isCoding(el))
-                .map((el) => el.code);
+                .map((el) => el.code)
+                .filter((code) => availableCodes.includes(code));
 
             if (storeItems.length === 0) {
-                if (available.value.value) {
-                    items.value = available.value.value.map((el) => el.code);
-                }
+                items.value = availableCodes;
                 return;
             }
 


### PR DESCRIPTION
## Summary

- Add a small green dot next to each `QueryFilterBox` title when any filter under that box is set (`active` boolean prop on the shared component).
- Add a shared reset button in the box header (left of the expand chevron) that emits a `reset` event consumers wire up. Visible only when the filter is active.
- Remove now-redundant per-box buttons:
  - `Zurücksetzen` from `QueryPatientFilters` and `RQueryDiagnosisFilter` (footer)
  - `Alle auswählen` / `Alle abwählen` from `MQueryDiagnosisFilter` and `MQueryMedicationFilter` (header row). These produced identical store state, which was misleading.
- Fix `RQueryDiagnosisFilter` to preserve URL-loaded filter state on mount instead of unconditionally wiping it via `reset()`.

## Test plan

- [ ] Open MTB query overview, expand each filter box (Patient, Diagnose, Therapien) and confirm the green dot appears only after narrowing the filter.
- [ ] Click the new header reset button; verify the filter clears, the green dot disappears, and the result set updates.
- [ ] Repeat for RD diagnosis filter.
- [ ] Reload a query URL that contains a diagnosis category filter (RD): selection should be preserved in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query filters now display a visual indicator when active filters are applied
  * Added reset functionality to individual filter headers, allowing users to quickly clear filter selections

* **Bug Fixes**
  * Improved filter state tracking across patient, diagnosis, and medication filters to accurately reflect current active filters

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnpm-dip/portal/pull/1201)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->