### PR TITLE
feat(query): move summary sidebar into secondary horizontal nav

### DIFF
--- a/packages/core/src/components/utility/nav/DNav.ts
+++ b/packages/core/src/components/utility/nav/DNav.ts
@@ -1,5 +1,6 @@
 import type { PropType, SlotsType } from 'vue';
 import { defineComponent, toRef } from 'vue';
+import { useRoute } from 'vue-router';
 import { buildNav } from './module';
 import type { NavItems } from './types';
 
@@ -23,10 +24,12 @@ export default defineComponent({
     setup(props, { slots }) {
         const items = toRef(props, 'items');
         const direction = toRef(props, 'direction');
+        const route = useRoute();
         return () => buildNav(props.path, items.value, {
             direction: direction.value,
             prevLink: props.prevLink,
             slots,
+            currentPath: route.path,
         });
     },
 });

--- a/packages/core/src/components/utility/nav/module.ts
+++ b/packages/core/src/components/utility/nav/module.ts
@@ -59,6 +59,22 @@ export function buildNav(
         return `${path}/${link}`;
     };
 
+    const itemLinks = items.map((item) => buildLink(item.urlSuffix));
+
+    let activeIndex = -1;
+    if (options.currentPath) {
+        const { currentPath } = options;
+        const matches = (link: string) => currentPath === link || currentPath.startsWith(`${link}/`);
+
+        let bestLength = -1;
+        for (const [i, link] of itemLinks.entries()) {
+            if (link && matches(link) && link.length > bestLength) {
+                bestLength = link.length;
+                activeIndex = i;
+            }
+        }
+    }
+
     const children : VNodeChild = [
         prevLink,
     ];
@@ -70,12 +86,13 @@ export function buildNav(
         children.push(normalizeSlot('start', {}, options.slots));
     }
 
-    children.push(...items.map((item) => h('li', { class: 'nav-item' }, [
+    children.push(...items.map((item, index) => h('li', { class: 'nav-item' }, [
         h(
             VCLink,
             {
                 class: 'nav-link',
-                to: buildLink(item.urlSuffix),
+                to: itemLinks[index],
+                active: index === activeIndex,
             },
             {
                 default: () => [

--- a/packages/core/src/components/utility/nav/types.ts
+++ b/packages/core/src/components/utility/nav/types.ts
@@ -12,5 +12,6 @@ export type NavItems = NavItem[];
 export type NavOptions = {
     direction?: 'vertical' | 'horizontal',
     prevLink?: boolean | string,
-    slots?: Slots
+    slots?: Slots,
+    currentPath?: string,
 };

--- a/packages/mtb/src/runtime/pages/query/[id]/index.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/index.vue
@@ -77,6 +77,41 @@ export default defineNuxtComponent({
             },
         ];
 
+        const summaryNavItems = [
+            {
+                name: 'Demographie',
+                icon: 'fas fa-globe',
+                urlSuffix: '',
+            },
+            {
+                name: 'Diagnose',
+                icon: 'fas fa-stethoscope',
+                urlSuffix: '/diagnostics',
+            },
+            {
+                name: 'Medikation',
+                icon: 'fas fa-pills',
+                urlSuffix: '/medication',
+            },
+            {
+                name: 'Therapie Responses',
+                icon: 'fas fa-comment-medical',
+                urlSuffix: '/therapy-responses',
+            },
+            {
+                name: 'Gen Alterationen',
+                icon: 'fas fa-dna',
+                urlSuffix: '/gene-alterations',
+            },
+            {
+                name: 'Überlebensbericht',
+                icon: 'fas fa-book-open',
+                urlSuffix: '/survival-report',
+            },
+        ];
+
+        const isSummaryActive = computed(() => route.path.startsWith(`/mtb/query/${props.entity.id}/summary`));
+
         const handleUpdated = (entity: QueryBase) => {
             emit('updated', entity);
 
@@ -95,6 +130,8 @@ export default defineNuxtComponent({
             toggleCriteriaExpansion,
 
             navItems,
+            summaryNavItems,
+            isSummaryActive,
             preparedQueryId: route.query.preparedQueryId,
 
             handleUpdated,
@@ -119,14 +156,27 @@ export default defineNuxtComponent({
     </div>
 
     <div class="d-flex flex-column gap-3">
-        <div class="d-flex flex-row">
-            <div>
-                <DNav
-                    :items="navItems"
-                    :path="'/mtb/query/'+ entity.id"
-                >
-                    <template #end />
-                </DNav>
+        <div class="d-flex flex-column gap-2">
+            <div class="d-flex flex-row">
+                <div>
+                    <DNav
+                        :items="navItems"
+                        :path="'/mtb/query/'+ entity.id"
+                    >
+                        <template #end />
+                    </DNav>
+                </div>
+            </div>
+            <div
+                v-if="isSummaryActive"
+                class="d-flex flex-row"
+            >
+                <div>
+                    <DNav
+                        :items="summaryNavItems"
+                        :path="'/mtb/query/'+ entity.id + '/summary'"
+                    />
+                </div>
             </div>
         </div>
 

--- a/packages/mtb/src/runtime/pages/query/[id]/index/summary.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/index/summary.vue
@@ -7,91 +7,22 @@
 
 <script lang="ts">
 import {
-    DNav,
-    type NavItem,
-} from '@dnpm-dip/core';
-import {
     type PropType,
 } from 'vue';
-import { ref } from 'vue';
 import { defineNuxtComponent } from '#imports';
 import type { QuerySession } from '../../../../domains';
 
 export default defineNuxtComponent({
-    components: { DNav },
     props: {
         entity: {
             type: Object as PropType<QuerySession>,
             required: true,
         },
     },
-    async setup() {
-        const navItems = [
-            {
-                id: 'default', 
-                name: 'Demographie', 
-                icon: 'fas fa-globe', 
-                urlSuffix: '',
-            },
-            {
-                id: 'diagnostics', 
-                name: 'Diagnose', 
-                icon: 'fas fa-stethoscope', 
-                urlSuffix: '/diagnostics',
-            },
-            {
-                id: 'medication', 
-                name: 'Medikation', 
-                icon: 'fas fa-pills', 
-                urlSuffix: '/medication',
-            },
-            {
-                id: 'therapyResponses', 
-                name: 'Therapie Responses', 
-                icon: 'fas fa-comment-medical', 
-                urlSuffix: '/therapy-responses',
-            },
-            {
-                id: 'geneAlterations', 
-                name: 'Gen Alterationen', 
-                icon: 'fas fa-dna', 
-                urlSuffix: '/gene-alterations',
-            },
-            {
-                id: 'survivalReport', 
-                name: 'Überlebensbericht', 
-                icon: 'fas fa-book-open', 
-                urlSuffix: '/survival-report',
-            },
-        ];
-
-        const navItemId = ref('default');
-
-        const setNavItem = (item: NavItem) => {
-            navItemId.value = item.id || 'default';
-        };
-
-        return {
-            navItems,
-            navItemId,
-            setNavItem,
-        };
-    },
 });
 </script>
 <template>
-    <div class="content-wrapper">
-        <div class="content-sidebar">
-            <DNav
-                :direction="'vertical'"
-                :items="navItems"
-                :path="'/mtb/query/'+ entity.id + '/summary'"
-            />
-        </div>
-        <div class="content-main">
-            <NuxtPage
-                :entity="entity"
-            />
-        </div>
-    </div>
+    <NuxtPage
+        :entity="entity"
+    />
 </template>

--- a/packages/rd/src/runtime/pages/query/[id]/index.vue
+++ b/packages/rd/src/runtime/pages/query/[id]/index.vue
@@ -3,13 +3,13 @@ import {
     DNav,
     DQueryFilterContainer,
     DQueryInfoBox,
-    DQueryPatientFilters, 
-    QueryEventBusEventName, 
+    DQueryPatientFilters,
+    QueryEventBusEventName,
     injectQueryEventBus,
 } from '@dnpm-dip/core';
 import type { PropType } from 'vue';
 import { BModal } from 'bootstrap-vue-next';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { defineNuxtComponent, useRoute } from '#imports';
 import QueryDiagnosisFilter from '../../../components/core/RQueryDiagnosisFilter.vue';
 import QueryHPOFilter from '../../../components/core/RQueryHPOFilter.vue';
@@ -40,21 +40,36 @@ export default defineNuxtComponent({
 
         const navItems = [
             {
-                name: 'Überblick', 
-                icon: 'fas fa-bars', 
-                urlSuffix: '',
+                name: 'Überblick',
+                icon: 'fas fa-bars',
+                urlSuffix: '/summary',
             },
             {
-                name: 'Patienten', 
-                icon: 'fas fa-user-injured', 
+                name: 'Patienten',
+                icon: 'fas fa-user-injured',
                 urlSuffix: '/patients',
             },
             {
-                name: 'Info', 
-                icon: 'fa fa-network-wired', 
+                name: 'Info',
+                icon: 'fa fa-network-wired',
                 urlSuffix: '/info',
             },
         ];
+
+        const summaryNavItems = [
+            {
+                name: 'Demographie',
+                icon: 'fas fa-globe',
+                urlSuffix: '',
+            },
+            {
+                name: 'Diagnostik',
+                icon: 'fas fa-stethoscope',
+                urlSuffix: '/diagnostics',
+            },
+        ];
+
+        const isSummaryActive = computed(() => route.path.startsWith(`/rd/query/${props.entity.id}/summary`));
 
         const handleSubmit = () => {
             // do nothing
@@ -92,6 +107,8 @@ export default defineNuxtComponent({
             handleModalUpdated,
 
             navItems,
+            summaryNavItems,
+            isSummaryActive,
             preparedQueryId: route.query.preparedQueryId,
         };
     },
@@ -112,23 +129,31 @@ export default defineNuxtComponent({
         </div>
     </div>
 
-    <div class="mb-2">
-        <DNav
-            :items="navItems"
-            :path="'/rd/query/'+ entity.id"
-        >
-            <template #end>
-                <li class="nav-item">
-                    <button
-                        type="button"
-                        class="nav-link"
-                        @click.prevent="toggleModal"
-                    >
-                        <i class="fa fa-cog" /> Anpassen
-                    </button>
-                </li>
-            </template>
-        </DNav>
+    <div class="d-flex flex-column gap-2 mb-2">
+        <div>
+            <DNav
+                :items="navItems"
+                :path="'/rd/query/'+ entity.id"
+            >
+                <template #end>
+                    <li class="nav-item">
+                        <button
+                            type="button"
+                            class="nav-link"
+                            @click.prevent="toggleModal"
+                        >
+                            <i class="fa fa-cog" /> Anpassen
+                        </button>
+                    </li>
+                </template>
+            </DNav>
+        </div>
+        <div v-if="isSummaryActive">
+            <DNav
+                :items="summaryNavItems"
+                :path="'/rd/query/'+ entity.id + '/summary'"
+            />
+        </div>
     </div>
 
     <hr>

--- a/packages/rd/src/runtime/pages/query/[id]/index/summary.vue
+++ b/packages/rd/src/runtime/pages/query/[id]/index/summary.vue
@@ -7,67 +7,22 @@
 
 <script lang="ts">
 import {
-    DNav,
-    type NavItem,
-} from '@dnpm-dip/core';
-import {
     type PropType,
 } from 'vue';
-import { ref } from 'vue';
 import { defineNuxtComponent } from '#imports';
 import type { QuerySession } from '../../../../domains';
 
 export default defineNuxtComponent({
-    components: { DNav },
     props: {
         entity: {
             type: Object as PropType<QuerySession>,
             required: true,
         },
     },
-    async setup() {
-        const navItems = [
-            {
-                id: 'default', 
-                name: 'Demographie', 
-                icon: 'fas fa-globe', 
-                urlSuffix: '',
-            },
-            {
-                id: 'diagnostics', 
-                name: 'Diagnostik', 
-                icon: 'fas fa-stethoscope', 
-                urlSuffix: '/diagnostics',
-            },
-        ];
-
-        const navItemId = ref('default');
-
-        const setNavItem = (item: NavItem) => {
-            navItemId.value = item.id || 'default';
-        };
-
-        return {
-            navItems,
-            navItemId,
-            setNavItem,
-        };
-    },
 });
 </script>
 <template>
-    <div class="content-wrapper">
-        <div class="content-sidebar">
-            <DNav
-                :direction="'vertical'"
-                :items="navItems"
-                :path="'/rd/query/'+ entity.id + '/summary'"
-            />
-        </div>
-        <div class="content-main">
-            <NuxtPage
-                :entity="entity"
-            />
-        </div>
-    </div>
+    <NuxtPage
+        :entity="entity"
+    />
 </template>


### PR DESCRIPTION
## Summary

- Replaces the vertical sidebar on the **Überblick** view with a secondary horizontal nav rendered below the main query nav (MTB & RD). The summary's sub-sections (Demographie, Diagnose, …) are now visible without an extra click, and the content area regains the sidebar's horizontal space.
- Fixes a pre-existing issue where the top-level **Überblick** tab wasn't highlighted on `/summary/*` sub-routes. `buildNav` now resolves the longest matching item link against the current route and passes `active` to `VCLink` explicitly, so single-level navs keep exact-match behavior while nested navs highlight the deepest match.
- RD's main-nav `Überblick` `urlSuffix` aligned with MTB (`/summary` instead of `''`) for consistent active-state matching.

## Test plan

- [ ] On `/mtb/query/{id}/summary`, secondary nav is visible and **Demographie** is highlighted; **Überblick** in main nav is highlighted.
- [ ] On `/mtb/query/{id}/summary/diagnostics`, **Diagnose** is highlighted in the sub-nav and **Überblick** remains highlighted in the main nav.
- [ ] On `/mtb/query/{id}/patients` and `/mtb/query/{id}/info`, the secondary nav is hidden.
- [ ] Same checks pass for RD (`/rd/query/{id}/summary` and `/summary/diagnostics`).
- [ ] Other DNav usages (admin sidebars, patient-detail tabs, settings) still highlight correctly.