### PR TITLE
chore(deps): bump @authup/* from beta.28 to beta.39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "vue-tsc": "^3.1.4"
             },
             "engines": {
-                "node": ">=22.0.0"
+                "node": "^22.13.0 || >=24.0.0"
             }
         },
         "node_modules/@antfu/install-pkg": {
@@ -22429,8 +22429,8 @@
             "version": "1.10.1",
             "license": "MIT",
             "dependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.28",
-                "@authup/core-kit": "^1.0.0-beta.28",
+                "@authup/client-web-kit": "^1.0.0-beta.39",
+                "@authup/core-kit": "^1.0.0-beta.39",
                 "@dnpm-dip/core": "^1.11.0",
                 "@dnpm-dip/kit": "^1.10.0",
                 "@nuxt/kit": "^4.4.5",
@@ -23119,8 +23119,8 @@
                 "ufo": "^1.6.2"
             },
             "devDependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.28",
-                "@authup/core-http-kit": "^1.0.0-beta.28",
+                "@authup/client-web-kit": "^1.0.0-beta.39",
+                "@authup/core-http-kit": "^1.0.0-beta.39",
                 "@ilingo/vuelidate": "^6.0.0",
                 "@nuxt/kit": "^4.4.5",
                 "@nuxt/schema": "^4.1.3",
@@ -23137,8 +23137,8 @@
                 "vue-chartjs": "^5.3.3"
             },
             "peerDependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.28",
-                "@authup/core-http-kit": "^1.0.0-beta.28",
+                "@authup/client-web-kit": "^1.0.0-beta.39",
+                "@authup/core-http-kit": "^1.0.0-beta.39",
                 "@ilingo/vuelidate": "^6.0.0",
                 "@nuxt/kit": "^4.4.5",
                 "@vuecs/form-controls": "^2.5.0",
@@ -23167,7 +23167,7 @@
             "version": "1.35.0",
             "license": "MIT",
             "dependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.28",
+                "@authup/client-web-kit": "^1.0.0-beta.39",
                 "@dnpm-dip/core": "^1.35.0",
                 "@dnpm-dip/kit": "^1.28.1",
                 "@nuxt/kit": "^4.4.5"
@@ -23857,11 +23857,11 @@
             "name": "@dnpm-dip/portal",
             "version": "1.34.0",
             "devDependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.28",
-                "@authup/client-web-nuxt": "^1.0.0-beta.28",
-                "@authup/core-http-kit": "^1.0.0-beta.28",
-                "@authup/core-kit": "^1.0.0-beta.28",
-                "@authup/kit": "^1.0.0-beta.28",
+                "@authup/client-web-kit": "^1.0.0-beta.39",
+                "@authup/client-web-nuxt": "^1.0.0-beta.39",
+                "@authup/core-http-kit": "^1.0.0-beta.39",
+                "@authup/core-kit": "^1.0.0-beta.39",
+                "@authup/kit": "^1.0.0-beta.39",
                 "@dnpm-dip/core": "^1.35.0",
                 "@dnpm-dip/kit": "^1.28.1",
                 "@dnpm-dip/mtb": "^1.35.0",
@@ -23896,7 +23896,7 @@
             "version": "1.34.0",
             "license": "MIT",
             "dependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.28",
+                "@authup/client-web-kit": "^1.0.0-beta.39",
                 "@dnpm-dip/core": "^1.35.0",
                 "@dnpm-dip/kit": "^1.28.1",
                 "@nuxt/kit": "^4.4.5"

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -30,8 +30,8 @@
         "test:watch": "vitest watch"
     },
     "dependencies": {
-        "@authup/core-kit": "^1.0.0-beta.28",
-        "@authup/client-web-kit": "^1.0.0-beta.28",
+        "@authup/core-kit": "^1.0.0-beta.39",
+        "@authup/client-web-kit": "^1.0.0-beta.39",
         "@dnpm-dip/core": "^1.11.0",
         "@dnpm-dip/kit": "^1.10.0",
         "@nuxt/kit": "^4.4.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,8 +47,8 @@
         "ufo": "^1.6.2"
     },
     "devDependencies": {
-        "@authup/core-http-kit": "^1.0.0-beta.28",
-        "@authup/client-web-kit": "^1.0.0-beta.28",
+        "@authup/core-http-kit": "^1.0.0-beta.39",
+        "@authup/client-web-kit": "^1.0.0-beta.39",
         "bootstrap-vue-next": "^0.45.3",
         "chart.js": "^4.5.1",
         "@ilingo/vuelidate": "^6.0.0",
@@ -65,8 +65,8 @@
         "vue-chartjs": "^5.3.3"
     },
     "peerDependencies": {
-        "@authup/core-http-kit": "^1.0.0-beta.28",
-        "@authup/client-web-kit": "^1.0.0-beta.28",
+        "@authup/core-http-kit": "^1.0.0-beta.39",
+        "@authup/client-web-kit": "^1.0.0-beta.39",
         "chart.js": "^4.4.3",
         "@ilingo/vuelidate": "^6.0.0",
         "@nuxt/kit": "^4.4.5",

--- a/packages/mtb/package.json
+++ b/packages/mtb/package.json
@@ -29,7 +29,7 @@
         "lint": "eslint ."
     },
     "dependencies": {
-        "@authup/client-web-kit": "^1.0.0-beta.28",
+        "@authup/client-web-kit": "^1.0.0-beta.39",
         "@dnpm-dip/core": "^1.35.0",
         "@dnpm-dip/kit": "^1.28.1",
         "@nuxt/kit": "^4.4.5"

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -17,11 +17,11 @@
         "start": "node .output/server/index.mjs"
     },
     "devDependencies": {
-        "@authup/client-web-kit": "^1.0.0-beta.28",
-        "@authup/client-web-nuxt": "^1.0.0-beta.28",
-        "@authup/core-http-kit": "^1.0.0-beta.28",
-        "@authup/core-kit": "^1.0.0-beta.28",
-        "@authup/kit": "^1.0.0-beta.28",
+        "@authup/client-web-kit": "^1.0.0-beta.39",
+        "@authup/client-web-nuxt": "^1.0.0-beta.39",
+        "@authup/core-http-kit": "^1.0.0-beta.39",
+        "@authup/core-kit": "^1.0.0-beta.39",
+        "@authup/kit": "^1.0.0-beta.39",
         "@dnpm-dip/core": "^1.35.0",
         "@dnpm-dip/kit": "^1.28.1",
         "@dnpm-dip/mtb": "^1.35.0",

--- a/packages/rd/package.json
+++ b/packages/rd/package.json
@@ -28,7 +28,7 @@
         "lint": "eslint ."
     },
     "dependencies": {
-        "@authup/client-web-kit": "^1.0.0-beta.28",
+        "@authup/client-web-kit": "^1.0.0-beta.39",
         "@dnpm-dip/core": "^1.35.0",
         "@dnpm-dip/kit": "^1.28.1",
         "@nuxt/kit": "^4.4.5"


### PR DESCRIPTION
## Summary

- Bumps all `@authup/*` packages (`client-web-kit`, `core-kit`, `core-http-kit`, `client-web-nuxt`, `kit`) from `^1.0.0-beta.28` to `^1.0.0-beta.39` across `admin`, `core`, `mtb`, `portal`, and `rd`.
- No source changes required — the consumed APIs (`storeToRefs`, `injectHTTPClient`, `usePermissionCheck`, `injectStore`, `wrapFnWithBusyState`, `injectHTTPClientAuthenticationHook`, `PermissionName`, `Role`/`User`/`IdentityProvider`, `A*Form` components) remained source-compatible across the 11-version jump.

## Verification

- `npm run build`: succeeds; TypeScript error count is identical to master (66 `TS2883` + 3 `TS4023`, all pre-existing and related to `bootstrap-vue-next` / `AEntityDelete` type re-exports).
- `npm run lint`: clean.

## Test plan

- [ ] Login flow via Authup still works.
- [ ] Admin pages (users, roles, identity-providers) — list/detail/edit forms render and submit.
- [ ] Permission-gated UI (e.g. site picker, query session creation) still respects user permissions.
- [ ] HTTP client requests carry valid auth tokens (smoke test any authed API call).