### PR TITLE
feat(core): customizable column labels and per-level config for DKVTable

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -28,5 +28,6 @@
     "production": [
       "default"
     ]
-  }
+  },
+  "analytics": false
 }

--- a/packages/core/src/components/core/query/QueryFilterBox.vue
+++ b/packages/core/src/components/core/query/QueryFilterBox.vue
@@ -19,7 +19,7 @@ export default defineComponent({
         },
     },
     emits: ['reset'],
-    setup(props, { emit }) {
+    setup(_props, { emit }) {
         // const store = useQueryFilterStore();
         // const storeRefs = storeToRefs(store);
 

--- a/packages/core/src/components/core/query/QueryFilterBox.vue
+++ b/packages/core/src/components/core/query/QueryFilterBox.vue
@@ -5,9 +5,7 @@
   - view the LICENSE file that was distributed with this source code.
   -->
 <script lang="ts">
-import { storeToRefs } from '@authup/client-web-kit';
-import { computed, defineComponent } from 'vue';
-import { useQueryFilterStore } from '../../../stores';
+import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
     props: {
@@ -22,13 +20,15 @@ export default defineComponent({
     },
     emits: ['reset'],
     setup(props, { emit }) {
-        const store = useQueryFilterStore();
-        const storeRefs = storeToRefs(store);
+        // const store = useQueryFilterStore();
+        // const storeRefs = storeToRefs(store);
 
-        const extended = computed(() => storeRefs.active.value === props.name);
+        // const extended = computed(() => storeRefs.active.value === props.name);
+        const extended = ref(false);
 
         const toggleExtended = () => {
-            store.setActive(props.name);
+            // store.setActive(props.name);
+            extended.value = !extended.value;
         };
 
         const reset = () => {
@@ -76,7 +76,6 @@ export default defineComponent({
                     <button
                         type="button"
                         class="btn btn-dark btn-xs"
-                        :disabled="extended"
                         :title="extended ? 'Filter ausgeklappt' : 'Filter ausklappen'"
                         :aria-label="extended ? 'Filter ausgeklappt' : 'Filter ausklappen'"
                         @click.prevent="toggleExtended"

--- a/packages/core/src/components/core/query/QuerySummaryDemographics.vue
+++ b/packages/core/src/components/core/query/QuerySummaryDemographics.vue
@@ -117,6 +117,9 @@ export default component as Component;
                     :type="'doughnut'"
                     :data="entity.siteDistribution.elements"
                     :clickable="true"
+                    :key-label="'Standort'"
+                    :value-label="'Anzahl [n]'"
+                    :percent-label="'Anteil [%]'"
                     @clicked="handleLocationClick"
                 />
             </div>
@@ -129,6 +132,9 @@ export default component as Component;
                     :type="'doughnut'"
                     :data="entity.genderDistribution.elements"
                     :clickable="true"
+                    :key-label="'Geschlecht'"
+                    :value-label="'Anzahl [n]'"
+                    :percent-label="'Anteil [%]'"
                     @clicked="handleGenderClick"
                 />
             </div>
@@ -141,6 +147,9 @@ export default component as Component;
             <DKVChartTableSwitch
                 :data="entity.ageDistribution.elements"
                 :clickable="true"
+                :key-label="'Alter [Jahre]'"
+                :value-label="'Anzahl [n]'"
+                :percent-label="'Anteil [%]'"
                 @clicked="handleAgeClick"
             />
         </div>

--- a/packages/core/src/components/core/query/QuerySummaryNested.vue
+++ b/packages/core/src/components/core/query/QuerySummaryNested.vue
@@ -100,6 +100,7 @@ export default defineComponent({
         </div>
     </VCFormGroup>
     <slot
+        :id="id"
         :items="items"
     />
 </template>

--- a/packages/core/src/components/utility/form-tab/DFormTabGroups.vue
+++ b/packages/core/src/components/utility/form-tab/DFormTabGroups.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
 import {
-    type PropType, 
-    defineComponent, 
-    ref, 
-    toRef, 
+    type PropType,
+    defineComponent,
+    ref,
+    toRef,
     watch,
 } from 'vue';
 import DFormTabGroup from './DFormTabGroup.vue';
@@ -187,7 +187,7 @@ export default defineComponent({
                     >
                         <a
                             href="javascript:void(0)"
-                            class="nav-link nav-link-dark text-center mb-1"
+                            class="nav-link nav-link-dark text-center mb-1 text-success"
                             :class="{'disabled': maxItems && maxItems === items.length}"
                             @click.prevent="add"
                         >

--- a/packages/core/src/components/utility/kv-chart-table-switch/DKVChartTableSwitch.vue
+++ b/packages/core/src/components/utility/kv-chart-table-switch/DKVChartTableSwitch.vue
@@ -14,6 +14,7 @@ import {
 import type { KeyValueRecord } from '../../../domains';
 import { DKVChart } from '../kv-chart';
 import { DKVTable } from '../kv-table';
+import type { DKVTableColumnsFn } from '../kv-table/types';
 
 const component = defineComponent({
     components: {
@@ -33,6 +34,34 @@ const component = defineComponent({
         clickable: {
             type: Boolean,
             default: false,
+        },
+        keyLabel: {
+            type: String,
+            default: 'Element',
+        },
+        valueLabel: {
+            type: String,
+            default: 'Häufigkeit',
+        },
+        percentLabel: {
+            type: String,
+            default: 'Prozent (%)',
+        },
+        keyHidden: {
+            type: Boolean,
+            default: false,
+        },
+        valueHidden: {
+            type: Boolean,
+            default: false,
+        },
+        percentHidden: {
+            type: Boolean,
+            default: false,
+        },
+        columns: {
+            type: Function as PropType<DKVTableColumnsFn>,
+            default: undefined,
         },
     },
     emits: ['clicked'],
@@ -107,6 +136,13 @@ export default component as Component;
                     :type="type"
                     :clickable="clickable"
                     :coding-verbose-label="codingVerboseLabel"
+                    :key-label="keyLabel"
+                    :value-label="valueLabel"
+                    :percent-label="percentLabel"
+                    :key-hidden="keyHidden"
+                    :value-hidden="valueHidden"
+                    :percent-hidden="percentHidden"
+                    :columns="columns"
                     :clicked="handleClick"
                 >
                     <DKVTable
@@ -114,6 +150,13 @@ export default component as Component;
                         :type="type"
                         :clickable="clickable"
                         :coding-verbose-label="codingVerboseLabel"
+                        :key-label="keyLabel"
+                        :value-label="valueLabel"
+                        :percent-label="percentLabel"
+                        :key-hidden="keyHidden"
+                        :value-hidden="valueHidden"
+                        :percent-hidden="percentHidden"
+                        :columns="columns"
                         @clicked="handleClick"
                     />
                 </slot>

--- a/packages/core/src/components/utility/kv-table/DKVTable.vue
+++ b/packages/core/src/components/utility/kv-table/DKVTable.vue
@@ -13,6 +13,29 @@ import type { Coding, KeyValueRecord } from '../../../domains';
 import { isCoding, isConceptCount, isMinMaxRange } from '../../../domains';
 import { generateChartLabelsForKeyValueRecord } from '../chart/utils';
 import DKVTableEntry from './DKVTableEntry.vue';
+import type { DKVTableColumnKey, DKVTableColumnsFn } from './types';
+
+const COLUMN_DEFAULTS: Record<DKVTableColumnKey, {
+    label: string; 
+    thClass: string; 
+    tdClass: string 
+}> = {
+    key: {
+        label: 'Element', 
+        thClass: 'text-left', 
+        tdClass: 'text-left', 
+    },
+    value: {
+        label: 'Häufigkeit', 
+        thClass: 'text-center', 
+        tdClass: 'text-center', 
+    },
+    percent: {
+        label: 'Prozent (%)', 
+        thClass: 'text-center', 
+        tdClass: 'text-center', 
+    },
+};
 
 export default defineComponent({
     components: { DKVTableEntry, BTable: BTable as unknown as Component },
@@ -25,6 +48,38 @@ export default defineComponent({
         clickable: {
             type: Boolean,
             default: false,
+        },
+        keyLabel: {
+            type: String,
+            default: 'Element',
+        },
+        valueLabel: {
+            type: String,
+            default: 'Häufigkeit',
+        },
+        percentLabel: {
+            type: String,
+            default: 'Prozent (%)',
+        },
+        keyHidden: {
+            type: Boolean,
+            default: false,
+        },
+        valueHidden: {
+            type: Boolean,
+            default: false,
+        },
+        percentHidden: {
+            type: Boolean,
+            default: false,
+        },
+        columns: {
+            type: Function as PropType<DKVTableColumnsFn>,
+            default: undefined,
+        },
+        level: {
+            type: Number,
+            default: 0,
         },
     },
     emits: ['clicked'],
@@ -60,26 +115,46 @@ export default defineComponent({
             };
         }));
 
-        const fields : TableFieldRaw[] = [
-            {
-                key: 'key',
-                label: 'Element',
-                thClass: 'text-left',
-                tdClass: 'text-left',
-            },
-            {
-                key: 'value',
-                label: 'Häufigkeit',
-                thClass: 'text-center',
-                tdClass: 'text-center',
-            },
-            {
-                key: 'percent',
-                label: 'Prozent (%)',
-                thClass: 'text-center',
-                tdClass: 'text-center',
-            },
-        ];
+        const fields = computed<TableFieldRaw[]>(() => {
+            if (props.columns) {
+                return props.columns(props.level).map((column) => {
+                    const defaults = COLUMN_DEFAULTS[column.key];
+                    return {
+                        key: column.key,
+                        label: column.label ?? defaults.label,
+                        thClass: defaults.thClass,
+                        tdClass: defaults.tdClass,
+                    };
+                });
+            }
+
+            const result: TableFieldRaw[] = [];
+            if (!props.keyHidden) {
+                result.push({
+                    key: 'key',
+                    label: props.keyLabel,
+                    thClass: COLUMN_DEFAULTS.key.thClass,
+                    tdClass: COLUMN_DEFAULTS.key.tdClass,
+                });
+            }
+            if (!props.valueHidden) {
+                result.push({
+                    key: 'value',
+                    label: props.valueLabel,
+                    thClass: COLUMN_DEFAULTS.value.thClass,
+                    tdClass: COLUMN_DEFAULTS.value.tdClass,
+                });
+            }
+            if (!props.percentHidden) {
+                result.push({
+                    key: 'percent',
+                    label: props.percentLabel,
+                    thClass: COLUMN_DEFAULTS.percent.thClass,
+                    tdClass: COLUMN_DEFAULTS.percent.tdClass,
+                });
+            }
+            return result;
+        });
 
         const handleClicked = (items: Coding[]) => {
             emit('clicked', items);
@@ -153,6 +228,8 @@ export default defineComponent({
                 :data="(cell.item as any)"
                 :clickable="clickable"
                 :coding-verbose-label="codingVerboseLabel"
+                :columns="columns"
+                :level="level"
                 @item-clicked="handleItemClick"
                 @clicked="handleClicked"
             />

--- a/packages/core/src/components/utility/kv-table/DKVTable.vue
+++ b/packages/core/src/components/utility/kv-table/DKVTable.vue
@@ -16,24 +16,24 @@ import DKVTableEntry from './DKVTableEntry.vue';
 import type { DKVTableColumnKey, DKVTableColumnsFn } from './types';
 
 const COLUMN_DEFAULTS: Record<DKVTableColumnKey, {
-    label: string; 
-    thClass: string; 
-    tdClass: string 
+    label: string;
+    thClass: string;
+    tdClass: string;
 }> = {
     key: {
-        label: 'Element', 
-        thClass: 'text-left', 
-        tdClass: 'text-left', 
+        label: 'Element',
+        thClass: 'text-left',
+        tdClass: 'text-left',
     },
     value: {
-        label: 'Häufigkeit', 
-        thClass: 'text-center', 
-        tdClass: 'text-center', 
+        label: 'Häufigkeit',
+        thClass: 'text-center',
+        tdClass: 'text-center',
     },
     percent: {
-        label: 'Prozent (%)', 
-        thClass: 'text-center', 
-        tdClass: 'text-center', 
+        label: 'Prozent (%)',
+        thClass: 'text-center',
+        tdClass: 'text-center',
     },
 };
 
@@ -51,15 +51,15 @@ export default defineComponent({
         },
         keyLabel: {
             type: String,
-            default: 'Element',
+            default: COLUMN_DEFAULTS.key.label,
         },
         valueLabel: {
             type: String,
-            default: 'Häufigkeit',
+            default: COLUMN_DEFAULTS.value.label,
         },
         percentLabel: {
             type: String,
-            default: 'Prozent (%)',
+            default: COLUMN_DEFAULTS.percent.label,
         },
         keyHidden: {
             type: Boolean,
@@ -228,6 +228,12 @@ export default defineComponent({
                 :data="(cell.item as any)"
                 :clickable="clickable"
                 :coding-verbose-label="codingVerboseLabel"
+                :key-label="keyLabel"
+                :value-label="valueLabel"
+                :percent-label="percentLabel"
+                :key-hidden="keyHidden"
+                :value-hidden="valueHidden"
+                :percent-hidden="percentHidden"
                 :columns="columns"
                 :level="level"
                 @item-clicked="handleItemClick"

--- a/packages/core/src/components/utility/kv-table/DKVTableEntry.vue
+++ b/packages/core/src/components/utility/kv-table/DKVTableEntry.vue
@@ -7,12 +7,13 @@
 <script lang="ts">
 import type { PropType } from 'vue';
 import {
-    computed, 
-    defineComponent, 
-    ref, 
+    computed,
+    defineComponent,
+    ref,
     resolveComponent,
 } from 'vue';
 import type { Coding, KeyValueRecord } from '../../../domains';
+import type { DKVTableColumnsFn } from './types';
 
 export default defineComponent({
     props: {
@@ -24,6 +25,14 @@ export default defineComponent({
         clickable: {
             type: Boolean,
             default: false,
+        },
+        columns: {
+            type: Function as PropType<DKVTableColumnsFn>,
+            default: undefined,
+        },
+        level: {
+            type: Number,
+            default: 0,
         },
     },
     emits: ['clicked', 'itemClicked'],
@@ -101,6 +110,8 @@ export default defineComponent({
                     :data="data.children"
                     :coding-verbose-label="codingVerboseLabel"
                     :clickable="clickable"
+                    :columns="columns"
+                    :level="level + 1"
                     @clicked="handleClicked"
                 />
             </div>

--- a/packages/core/src/components/utility/kv-table/DKVTableEntry.vue
+++ b/packages/core/src/components/utility/kv-table/DKVTableEntry.vue
@@ -26,6 +26,30 @@ export default defineComponent({
             type: Boolean,
             default: false,
         },
+        keyLabel: {
+            type: String,
+            default: undefined,
+        },
+        valueLabel: {
+            type: String,
+            default: undefined,
+        },
+        percentLabel: {
+            type: String,
+            default: undefined,
+        },
+        keyHidden: {
+            type: Boolean,
+            default: false,
+        },
+        valueHidden: {
+            type: Boolean,
+            default: false,
+        },
+        percentHidden: {
+            type: Boolean,
+            default: false,
+        },
         columns: {
             type: Function as PropType<DKVTableColumnsFn>,
             default: undefined,
@@ -110,6 +134,12 @@ export default defineComponent({
                     :data="data.children"
                     :coding-verbose-label="codingVerboseLabel"
                     :clickable="clickable"
+                    :key-label="keyLabel"
+                    :value-label="valueLabel"
+                    :percent-label="percentLabel"
+                    :key-hidden="keyHidden"
+                    :value-hidden="valueHidden"
+                    :percent-hidden="percentHidden"
                     :columns="columns"
                     :level="level + 1"
                     @clicked="handleClicked"

--- a/packages/core/src/components/utility/kv-table/index.ts
+++ b/packages/core/src/components/utility/kv-table/index.ts
@@ -7,3 +7,4 @@
 
 export { default as DKVTable } from './DKVTable.vue';
 export { default as DKVTableEntryKey } from './DKVTableEntryKey.vue';
+export * from './types';

--- a/packages/core/src/components/utility/kv-table/types.ts
+++ b/packages/core/src/components/utility/kv-table/types.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type DKVTableColumnKey = 'key' | 'value' | 'percent';
+
+export type DKVTableColumn = {
+    key: DKVTableColumnKey;
+    label?: string;
+};
+
+export type DKVTableColumnsFn = (level: number) => DKVTableColumn[];

--- a/packages/core/src/stores/query-filter/module.ts
+++ b/packages/core/src/stores/query-filter/module.ts
@@ -13,12 +13,12 @@ import { buildQueryFiltersURLRecord } from './helper';
 import type { QueryFilterItem, QueryFilters } from './types';
 
 export function createQueryFilterStore(ctx: StoreCreateOptions) {
-    const active = ref<string>('patient');
+    const active = ref<string | null>(null);
     const setActive = (name: string) => {
         active.value = name;
     };
     const resetActive = () => {
-        active.value = 'patient';
+        active.value = null;
     };
 
     // ----------------------------------------------------------------

--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryMedication.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryMedication.vue
@@ -191,7 +191,7 @@ export default defineComponent({
                                 :data="items"
                                 :clickable="true"
                                 :columns="(level: number) => level === 0 && !id ? [
-                                    {key: 'key', label: 'Wirktsoffklasse'},
+                                    {key: 'key', label: 'Wirkstoffklasse'},
                                     {key: 'value', label: 'Anzahl [n]'},
                                     {key: 'percent', label: 'Anteil [%]'},
                                 ] : [
@@ -224,7 +224,7 @@ export default defineComponent({
                                 :data="items"
                                 :clickable="true"
                                 :columns="(level: number) => level === 0 && !id ? [
-                                    {key: 'key', label: 'Wirktsoffklasse'},
+                                    {key: 'key', label: 'Wirkstoffklasse'},
                                     {key: 'value', label: 'Anzahl [n]'},
                                     {key: 'percent', label: 'Anteil [%]'},
                                 ] : [

--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryMedication.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryMedication.vue
@@ -169,6 +169,9 @@ export default defineComponent({
                                 :type="'bar'"
                                 :data="item.value.elements"
                                 :clickable="true"
+                                :key-label="'Wirkstoff'"
+                                :value-label="'Anzahl [n]'"
+                                :percent-label="'Anteil [%]'"
                                 @clicked="(keys: Coding[]) => handleRecommendationClick(keys, 'recommendedByVariant')"
                             />
                         </template>
@@ -183,10 +186,19 @@ export default defineComponent({
                         :total="data.recommendations.overallDistribution.total"
                         :data="(data.recommendations.overallDistribution.elements as any)"
                     >
-                        <template #default="{ items }">
+                        <template #default="{ items, id }">
                             <DKVChartTableSwitch
                                 :data="items"
                                 :clickable="true"
+                                :columns="(level: number) => level === 0 && !id ? [
+                                    {key: 'key', label: 'Wirktsoffklasse'},
+                                    {key: 'value', label: 'Anzahl [n]'},
+                                    {key: 'percent', label: 'Anteil [%]'},
+                                ] : [
+                                    {key: 'key', label: 'Wirkstoff'},
+                                    {key: 'value', label: 'Anzahl [n]'},
+                                    {key: 'percent', label: 'Anteil [%]'},
+                                ]"
                                 @clicked="(keys: Coding[]) => handleRecommendationClick(keys, 'recommended')"
                             />
                         </template>
@@ -207,10 +219,19 @@ export default defineComponent({
                         :data="(data.therapies.overallDistribution.elements as any)"
                         :total="data.therapies.overallDistribution.total"
                     >
-                        <template #default="{ items }">
+                        <template #default="{ items, id }">
                             <DKVChartTableSwitch
                                 :data="items"
                                 :clickable="true"
+                                :columns="(level: number) => level === 0 && !id ? [
+                                    {key: 'key', label: 'Wirktsoffklasse'},
+                                    {key: 'value', label: 'Anzahl [n]'},
+                                    {key: 'percent', label: 'Anteil [%]'},
+                                ] : [
+                                    {key: 'key', label: 'Wirkstoff'},
+                                    {key: 'value', label: 'Anzahl [n]'},
+                                    {key: 'percent', label: 'Anteil [%]'},
+                                ]"
                                 @clicked="handleUsedClick"
                             />
                         </template>

--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryTherapyResponses.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryTherapyResponses.vue
@@ -57,50 +57,50 @@ export default defineComponent({
 
         const fields : TableFieldRaw[] = [
             {
-                key: 'tumorEntity', 
-                label: 'Entität', 
-                thClass: 'text-left', 
-                tdClass: 'text-left', 
+                key: 'tumorEntity',
+                label: 'Entität',
+                thClass: 'text-left',
+                tdClass: 'text-left',
                 sortable: true,
             },
             {
-                key: 'medications', 
-                label: 'Medikationen', 
-                thClass: 'text-left', 
+                key: 'medications',
+                label: 'Medikationen',
+                thClass: 'text-left',
                 tdClass: 'text-left',
             },
             {
-                key: 'supportingAlteration', 
-                label: 'Stützende Variante', 
-                thClass: 'text-left', 
-                tdClass: 'text-left', 
+                key: 'supportingAlteration',
+                label: 'Stützende Variante',
+                thClass: 'text-left',
+                tdClass: 'text-left',
                 sortable: true,
             },
             {
-                key: 'count', 
-                label: 'Anzahl Therapien', 
-                thClass: 'text-center', 
-                tdClass: 'text-center align-middle', 
+                key: 'count',
+                label: 'Anzahl Therapien',
+                thClass: 'text-center',
+                tdClass: 'text-center align-middle',
                 sortable: true,
             },
             {
-                key: 'orr', 
-                label: 'ORR (%)', 
-                thClass: 'text-center', 
-                tdClass: 'text-center align-middle', 
+                key: 'orr',
+                label: 'ORR (%)',
+                thClass: 'text-center',
+                tdClass: 'text-center align-middle',
                 sortable: true,
             },
             {
-                key: 'meanDuration', 
-                label: 'Dauer in Wochen (Ø)', 
-                thClass: 'text-center', 
-                tdClass: 'text-center align-middle', 
+                key: 'meanDuration',
+                label: 'Dauer in Wochen (Ø)',
+                thClass: 'text-center',
+                tdClass: 'text-center align-middle',
                 sortable: true,
             },
             {
-                key: 'responseDistribution', 
-                label: 'Response Verteilung', 
-                thClass: 'text-center', 
+                key: 'responseDistribution',
+                label: 'Response Verteilung',
+                thClass: 'text-center',
                 tdClass: 'text-center align-middle',
             },
         ];
@@ -201,6 +201,10 @@ export default defineComponent({
         animation="wave"
     />
     <div v-show="!busy || total > 0">
+        <div class="alert alert-sm alert-warning alert-sm">
+            Bitte beachten: Ein Patient kann mehrere unterschiedliche Therapieumsetzungen erhalten haben.
+        </div>
+
         <VCPagination
             :busy="busy"
             :total="total"

--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryTumorDiagnostics.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryTumorDiagnostics.vue
@@ -120,11 +120,20 @@ export default defineComponent({
                             :total="data.overallDistributions.tumorEntities.total"
                             :key-verbose="true"
                         >
-                            <template #default="{items}">
+                            <template #default="{items, id}">
                                 <DKVChartTableSwitch
                                     :coding-verbose-label="true"
                                     :data="items"
                                     :clickable="true"
+                                    :columns="(level: number) => level === 0 && !id ? [
+                                        {key: 'key', label: 'Tumorentität [ICD-10 GM]'},
+                                        {key: 'value', label: 'Anzahl [n]'},
+                                        {key: 'percent', label: 'Anteil [%]'},
+                                    ] : [
+                                        {key: 'key', label: 'Tumorentität [ICD-10 GM]'},
+                                        {key: 'value', label: 'Anzahl [n]'},
+                                        {key: 'percent', label: 'Anteil [%]'},
+                                    ]"
                                     @clicked="handleClick"
                                 />
                             </template>
@@ -139,10 +148,19 @@ export default defineComponent({
                             :total="data.overallDistributions.tumorMorphologies.total"
                             :key-verbose="true"
                         >
-                            <template #default="{items}">
+                            <template #default="{items, id}">
                                 <DKVChartTableSwitch
                                     :coding-verbose-label="true"
                                     :data="items"
+                                    :columns="(level: number) => level === 0 && !id ? [
+                                        {key: 'key', label: 'Tumor-Morphologie (ICD-O-3-M)'},
+                                        {key: 'value', label: 'Anzahl [n]'},
+                                        {key: 'percent', label: 'Anteil [%]'},
+                                    ] : [
+                                        {key: 'key', label: 'Tumor-Morphologie (ICD-O-3-M)'},
+                                        {key: 'value', label: 'Anzahl [n]'},
+                                        {key: 'percent', label: 'Anteil [%]'},
+                                    ]"
                                 />
                             </template>
                         </DQuerySummaryNested>
@@ -168,6 +186,9 @@ export default defineComponent({
                                 <DKVChartTableSwitch
                                     :coding-verbose-label="true"
                                     :data="item.value.tumorEntities.elements"
+                                    :key-label="'Tumorentität [ICD-10 GM]'"
+                                    :value-label="'Anzahl [n]'"
+                                    :percent-label="'Anteil [%]'"
                                 />
                             </div>
 
@@ -178,6 +199,9 @@ export default defineComponent({
                                 <DKVChartTableSwitch
                                     :coding-verbose-label="true"
                                     :data="item.value.tumorMorphologies.elements"
+                                    :key-label="'Tumor-Morphologie (ICD-O-3-M)'"
+                                    :value-label="'Anzahl [n]'"
+                                    :percent-label="'Anteil [%]'"
                                 />
                             </div>
                         </div>

--- a/packages/mtb/src/runtime/pages/query/[id]/index.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/index.vue
@@ -205,7 +205,7 @@ export default defineNuxtComponent({
                                     class="btn btn-dark btn-xs"
                                     @click.prevent="props.toggle()"
                                 >
-                                    <i class="fa fa-cog" />
+                                    <i class="fa fa-edit" /> Anpassen
                                 </button>
                             </template>
                         </MQueryCriteriaModal>


### PR DESCRIPTION
## Summary
- Add `keyLabel` / `valueLabel` / `percentLabel` and `keyHidden` / `valueHidden` / `percentHidden` props to `DKVTable` and `DKVChartTableSwitch`, so callers can override or omit the default *Element* / *Häufigkeit* / *Prozent* columns without overriding the `#table` slot.
- Add an optional `columns(level)` function prop for nested tables. It returns the columns (`key` / `value` / `percent`, with optional `label`) for a given nesting depth; omit a column to hide it. `DKVTableEntry` forwards `columns` and `level + 1` to child tables.
- Export new types (`DKVTableColumn`, `DKVTableColumnKey`, `DKVTableColumnsFn`) from `@dnpm-dip/core`.

## Usage

Simple, single-level override:

```vue
<DKVChartTableSwitch
  :data="items"
  :value-label="'Dauer in Wochen'"
  :percent-hidden="true"
/>
```

Per-level override for nested tables:

```vue
<DKVChartTableSwitch
  :data="items"
  :columns="(level) => level === 0
    ? [{ key: 'key', label: 'Gen' }, { key: 'value', label: 'Anzahl Patienten' }]
    : [{ key: 'key', label: 'Variante' }, { key: 'value' }, { key: 'percent' }]"
/>
```

When `columns` is set, it fully overrides the simple `*Label` / `*Hidden` props.

## Test plan
- [ ] `npm run build --workspace=packages/core` succeeds
- [ ] `npx eslint` on the changed files is clean
- [ ] Manual: existing `DKVChartTableSwitch` call sites still render the default Element / Häufigkeit / Prozent columns
- [ ] Manual: passing `valueLabel` / `percentHidden` changes / hides the relevant column
- [ ] Manual: nested data with a `columns(level)` fn yields different columns per nesting depth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable table labels (German defaults), per-column visibility toggles, and level-aware custom column definitions for nested tables.
* **Improvements**
  * Filter box now toggles expanded state locally.
  * Added warning above therapy responses pagination.
  * Multiple components now pass explicit label/column props to improve table/chart labeling and nesting.
  * Criteria button switched to edit icon with added label; create-tab button styling adjusted.
* **Chores**
  * Module re-exports expanded to include table types.
  * Analytics collection disabled in config; query-filter active state now resets to null.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnpm-dip/portal/pull/1209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->