### PR TITLE
feat: apply ZPM feedback to MTB query summary and search form

### DIFF
--- a/packages/core/src/components/core/query/QuerySummaryDemographics.vue
+++ b/packages/core/src/components/core/query/QuerySummaryDemographics.vue
@@ -12,6 +12,14 @@ const component = defineComponent({
             type: Object as PropType<QuerySummaryDemographics>,
             required: true,
         },
+        withTotals: {
+            type: Boolean,
+            default: false,
+        },
+        withAxisLabels: {
+            type: Boolean,
+            default: false,
+        },
     },
     emits: ['navigate'],
     setup(_props, { emit }) {
@@ -111,7 +119,7 @@ export default component as Component;
         <div class="d-flex flex-row gap-2">
             <div class="entity-card text-center mb-3 w-100">
                 <h6>
-                    Patienten pro Standort
+                    {{ withTotals ? `Patienten pro Standort (N = ${entity.siteDistribution.total})` : 'Patienten pro Standort' }}
                 </h6>
                 <DKVChartTableSwitch
                     :type="'doughnut'"
@@ -126,7 +134,7 @@ export default component as Component;
 
             <div class="entity-card text-center mb-3 w-100">
                 <h6>
-                    Geschlechterverteilung
+                    {{ withTotals ? `Geschlechterverteilung (N = ${entity.genderDistribution.total})` : 'Geschlechterverteilung' }}
                 </h6>
                 <DKVChartTableSwitch
                     :type="'doughnut'"
@@ -142,7 +150,7 @@ export default component as Component;
 
         <div class="entity-card text-center mb-3 w-100">
             <h6>
-                Altersverteilung
+                {{ withTotals ? `Altersverteilung (N = ${entity.ageDistribution.total})` : 'Altersverteilung' }}
             </h6>
             <DKVChartTableSwitch
                 :data="entity.ageDistribution.elements"
@@ -150,6 +158,8 @@ export default component as Component;
                 :key-label="'Alter [Jahre]'"
                 :value-label="'Anzahl [n]'"
                 :percent-label="'Anteil [%]'"
+                :x-axis-label="withAxisLabels ? 'Anzahl [n]' : undefined"
+                :y-axis-label="withAxisLabels ? 'Alter [Jahre] (Anteil [%])' : undefined"
                 @clicked="handleAgeClick"
             />
         </div>

--- a/packages/core/src/components/core/query/QuerySummaryGrouped.vue
+++ b/packages/core/src/components/core/query/QuerySummaryGrouped.vue
@@ -25,6 +25,10 @@ export default defineComponent({
             type: String,
             default: 'Gruppe',
         },
+        placeholder: {
+            type: String,
+            default: '...',
+        },
         items: { type: Array as PropType<KeyValueRecord<unknown, unknown>[]> },
         selectFirst: {
             type: Boolean,
@@ -119,6 +123,7 @@ export default defineComponent({
         <VCFormSelectSearch
             v-model="id"
             :options="options"
+            :placeholder="placeholder"
         />
     </VCFormGroup>
     <template v-if="item">

--- a/packages/core/src/components/core/query/QuerySummaryNested.vue
+++ b/packages/core/src/components/core/query/QuerySummaryNested.vue
@@ -20,6 +20,10 @@ export default defineComponent({
             type: String,
             default: 'Gruppe',
         },
+        placeholder: {
+            type: String,
+            default: '...',
+        },
         data: {
             type: Array as PropType<DistributionNestedElements<Coding>>,
             required: true,
@@ -89,6 +93,7 @@ export default defineComponent({
             <VCFormSelectSearch
                 v-model="id"
                 :options="options"
+                :placeholder="placeholder"
             />
             <button
                 v-show="id"

--- a/packages/core/src/components/utility/kv-chart-table-switch/DKVChartTableSwitch.vue
+++ b/packages/core/src/components/utility/kv-chart-table-switch/DKVChartTableSwitch.vue
@@ -31,6 +31,14 @@ const component = defineComponent({
             type: Array as PropType<KeyValueRecord<unknown, unknown>[]>,
         },
         codingVerboseLabel: { type: Boolean },
+        xAxisLabel: {
+            type: String,
+            default: undefined,
+        },
+        yAxisLabel: {
+            type: String,
+            default: undefined,
+        },
         clickable: {
             type: Boolean,
             default: false,
@@ -126,6 +134,8 @@ export default component as Component;
                         :items="data"
                         :type="type"
                         :coding-verbose-label="codingVerboseLabel"
+                        :x-axis-label="xAxisLabel"
+                        :y-axis-label="yAxisLabel"
                     />
                 </slot>
             </template>

--- a/packages/core/src/components/utility/kv-chart/DKVChart.vue
+++ b/packages/core/src/components/utility/kv-chart/DKVChart.vue
@@ -1,8 +1,9 @@
 <script lang="ts">
 import type {
-    ChartData, 
+    ChartData,
     ChartOptions,
 } from 'chart.js';
+import { merge } from 'smob';
 import type { Component, PropType } from 'vue';
 import { computed, defineComponent } from 'vue';
 import type { Coding, KeyValueRecord, MinMaxRange } from '../../../domains';
@@ -30,6 +31,14 @@ const component = defineComponent({
         },
         options: { type: Object as PropType<ChartOptions> },
         codingVerboseLabel: { type: Boolean },
+        xAxisLabel: {
+            type: String,
+            default: undefined,
+        },
+        yAxisLabel: {
+            type: String,
+            default: undefined,
+        },
         limit: {
             type: Number,
             default: 25,
@@ -81,11 +90,29 @@ const component = defineComponent({
             }),
         }));
 
+        const chartOptions = computed<ChartOptions | undefined>(() => {
+            const scales: Record<string, unknown> = {};
+            if (props.xAxisLabel) {
+                scales.x = { title: { display: true, text: props.xAxisLabel } };
+            }
+            if (props.yAxisLabel) {
+                scales.y = { title: { display: true, text: props.yAxisLabel } };
+            }
+
+            const hasScales = Object.keys(scales).length > 0;
+            if (!props.options && !hasScales) {
+                return undefined;
+            }
+
+            return merge({}, props.options || {}, hasScales ? { scales } : {});
+        });
+
         return {
             itemsMissing,
             itemsDisplayed,
             itemsTotal,
             data,
+            chartOptions,
         };
     },
 });
@@ -105,7 +132,7 @@ export default component as Component;
             <DChart
                 :type="type"
                 :data="data"
-                :options="options"
+                :options="chartOptions"
             />
         </div>
     </div>

--- a/packages/core/src/components/utility/kv-chart/DKVChart.vue
+++ b/packages/core/src/components/utility/kv-chart/DKVChart.vue
@@ -16,7 +16,7 @@ import {
 import { DChart } from '../chart';
 import { generateChartLabelsForKeyValueRecord } from '../chart/utils';
 
-type Key = MinMaxRange | Coding | string[] | string;
+type Key = MinMaxRange | Coding | Coding[] | string[] | string;
 
 const component = defineComponent({
     components: { DChart },

--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryDemographics.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryDemographics.vue
@@ -64,7 +64,11 @@ export default defineComponent({
 </script>
 <template>
     <template v-if="data">
-        <DQuerySummaryDemographics :entity="data" />
+        <DQuerySummaryDemographics
+            :entity="data"
+            :with-totals="true"
+            :with-axis-labels="true"
+        />
     </template>
     <template v-else-if="busy">
         <div>

--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryGeneAlterations.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryGeneAlterations.vue
@@ -66,6 +66,7 @@ export default defineComponent({
                 label: 'Gen',
                 thClass: 'text-left',
                 tdClass: 'text-left',
+                sortable: true,
             },
             {
                 key: 'alteration',

--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryGeneAlterationsDistribution.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryGeneAlterationsDistribution.vue
@@ -71,16 +71,24 @@ export default defineComponent({
 <template>
     <template v-if="data">
         <div>
-            <h5>Verteilung nach Alteration</h5>
+            <h5>TOP 20 der alterierten Gene (SNV/ CNV/ Fusion)</h5>
             <DQuerySummaryGrouped
-                :select-first="true"
                 :items="data"
                 :label="'Alteration'"
+                :placeholder="'Alterationsart auswählen'"
             >
                 <template #default="{ item }">
+                    <p class="text-start mb-2">
+                        N (alterierte Gene) = {{ item.value.elements.length }}
+                    </p>
                     <DKVChartTableSwitch
                         :type="'bar'"
-                        :data="item.value.elements"
+                        :data="item.value.elements.slice(0, 20)"
+                        :key-label="'alteriertes Gen'"
+                        :value-label="'Anzahl [n]'"
+                        :percent-label="'Anteil [%]'"
+                        :x-axis-label="'Anzahl [n]'"
+                        :y-axis-label="'alteriertes Gen (Anteil [%])'"
                     />
                 </template>
             </DQuerySummaryGrouped>
@@ -88,7 +96,7 @@ export default defineComponent({
     </template>
     <template v-else-if="busy">
         <div>
-            <h5>Verteilung nach Alteration</h5>
+            <h5>TOP 20 der alterierten Gene (SNV/ CNV/ Fusion)</h5>
             <div class="entity-card text-center mb-3">
                 <BPlaceholder
                     v-for="i in 5"

--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryMedication.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryMedication.vue
@@ -9,8 +9,8 @@
 import { wrapFnWithBusyState } from '@authup/client-web-kit';
 import {
     type Coding,
+    DKVChart,
     DKVChartTableSwitch,
-    DKVTableEntryKey,
     DQuerySummaryGrouped,
     DQuerySummaryNested,
     QueryEventBusEventName,
@@ -18,9 +18,13 @@ import {
     toCodingGroup,
     useQueryFilterStore,
 } from '@dnpm-dip/core';
-import { BPlaceholder, BTable } from 'bootstrap-vue-next';
-import type { Component } from 'vue';
-import { defineComponent, onUnmounted, ref } from 'vue';
+import { BPlaceholder } from 'bootstrap-vue-next';
+import {
+    computed,
+    defineComponent,
+    onUnmounted,
+    ref,
+} from 'vue';
 import { QueryFilterURLKey } from '../../../constants';
 import { injectHTTPClient } from '../../../core/http-client';
 import type { QueryGeneAlteration, QuerySummaryMedication } from '../../../domains';
@@ -29,11 +33,10 @@ import { queryGeneAlterationToString } from '../../../domains';
 export default defineComponent({
     components: {
         BPlaceholder,
-        DKVTableEntryKey,
+        DKVChart,
         DKVChartTableSwitch,
         DQuerySummaryNested,
         DQuerySummaryGrouped,
-        BTable: BTable as unknown as Component,
     },
     props: {
         queryId: {
@@ -131,6 +134,40 @@ export default defineComponent({
             }
         };
 
+        const meanDurationTree = computed(() => {
+            if (!data.value) {
+                return [];
+            }
+
+            // The API provides no class-level duration; classes are only a grouping
+            // for the per-drug durations. The numeric value here is a placeholder so
+            // DKVTable can resolve the class label, and is never displayed (hidden at
+            // class level in the table, flattened past in the chart).
+            return data.value.therapies.meanDurations.map((group) => ({
+                key: group.key,
+                value: 0,
+                children: group.value,
+            }));
+        });
+
+        const flattenMeanDurations = (items: { children?: unknown[] }[]) => items.flatMap(
+            (item) => (Array.isArray(item.children) && item.children.length > 0 ?
+                item.children :
+                [item]),
+        );
+
+        const variantLabelFn = (item: { key: unknown }) => {
+            if (typeof item.key === 'string') {
+                return item.key;
+            }
+
+            if (item.key && typeof item.key === 'object') {
+                return queryGeneAlterationToString(item.key as QueryGeneAlteration);
+            }
+
+            return '???';
+        };
+
         return {
             busy,
             data,
@@ -138,13 +175,14 @@ export default defineComponent({
 
             recommendedVNode,
             recommendedByVariantVNode,
-            variantLabelFn: (item: { key: unknown }) => (typeof item.key === 'string' ?
-                item.key :
-                queryGeneAlterationToString(item.key as QueryGeneAlteration)),
+            variantLabelFn,
             handleRecommendationClick,
 
             usedVNode,
             handleUsedClick,
+
+            meanDurationTree,
+            flattenMeanDurations,
         };
     },
 });
@@ -157,32 +195,46 @@ export default defineComponent({
                 <div class="entity-card text-center mb-3 w-100">
                     <h6>Empfehlungen nach stützender molekularer Alteration</h6>
 
-                    <DQuerySummaryGrouped
-                        ref="recommendedByVariantVNode"
-                        :select-first="true"
-                        :items="data.recommendations.distributionBySupportingVariant"
-                        :label="'Variante'"
-                        :label-fn="variantLabelFn"
-                    >
-                        <template #default="{ item }">
-                            <DKVChartTableSwitch
-                                :type="'bar'"
-                                :data="item.value.elements"
-                                :clickable="true"
-                                :key-label="'Wirkstoff'"
-                                :value-label="'Anzahl [n]'"
-                                :percent-label="'Anteil [%]'"
-                                @clicked="(keys: Coding[]) => handleRecommendationClick(keys, 'recommendedByVariant')"
-                            />
-                        </template>
-                    </DQuerySummaryGrouped>
+                    <template v-if="data.recommendations.distributionBySupportingVariant.length > 0">
+                        <DQuerySummaryGrouped
+                            ref="recommendedByVariantVNode"
+                            :select-first="true"
+                            :items="data.recommendations.distributionBySupportingVariant"
+                            :label="'Variante'"
+                            :placeholder="'Variante auswählen'"
+                            :label-fn="variantLabelFn"
+                        >
+                            <template #default="{ item }">
+                                <p class="text-start mb-2">
+                                    Gesamtzahl Empfehlungen nach ausgewählter stützender molekularer Alteration: N = {{ item.value.total }}
+                                </p>
+                                <DKVChartTableSwitch
+                                    :type="'bar'"
+                                    :data="item.value.elements"
+                                    :clickable="true"
+                                    :key-label="'Wirkstoff'"
+                                    :value-label="'Anzahl Empfehlungen [n]'"
+                                    :percent-label="'Anteil Empfehlungen (basierend auf Variante) [%]'"
+                                    :x-axis-label="'Anzahl Empfehlungen [n]'"
+                                    :y-axis-label="'Wirkstoff'"
+                                    @clicked="(keys: Coding[]) => handleRecommendationClick(keys, 'recommendedByVariant')"
+                                />
+                            </template>
+                        </DQuerySummaryGrouped>
+                    </template>
+                    <template v-else>
+                        <div class="alert alert-sm alert-info mb-0">
+                            Es sind keine stützenden molekularen Alterationen hinterlegt.
+                        </div>
+                    </template>
                 </div>
                 <div class="entity-card text-center mb-3 w-100">
-                    <h6>Gesamtverteilung der Empfehlungen nach Wirkstoffklasse ({{ data.recommendations.overallDistribution.total }})</h6>
+                    <h6>Gesamtverteilung der Empfehlungen nach Wirkstoffklasse (N = {{ data.recommendations.overallDistribution.total }})</h6>
 
                     <DQuerySummaryNested
                         ref="recommendedVNode"
                         :label="'Kategorie'"
+                        :placeholder="'Kategorie auswählen'"
                         :total="data.recommendations.overallDistribution.total"
                         :data="(data.recommendations.overallDistribution.elements as any)"
                     >
@@ -190,14 +242,16 @@ export default defineComponent({
                             <DKVChartTableSwitch
                                 :data="items"
                                 :clickable="true"
+                                :x-axis-label="'Anzahl Empfehlungen [n]'"
+                                :y-axis-label="'Wirkstoffklasse bzw. Wirkstoff'"
                                 :columns="(level: number) => level === 0 && !id ? [
                                     {key: 'key', label: 'Wirkstoffklasse'},
-                                    {key: 'value', label: 'Anzahl [n]'},
-                                    {key: 'percent', label: 'Anteil [%]'},
+                                    {key: 'value', label: 'Anzahl Empfehlungen [n]'},
+                                    {key: 'percent', label: 'Anteil Empfehlungen [%]'},
                                 ] : [
                                     {key: 'key', label: 'Wirkstoff'},
                                     {key: 'value', label: 'Anzahl [n]'},
-                                    {key: 'percent', label: 'Anteil [%]'},
+                                    {key: 'percent', label: 'Anteil bzgl. Wirkstoffklasse [%]'},
                                 ]"
                                 @clicked="(keys: Coding[]) => handleRecommendationClick(keys, 'recommended')"
                             />
@@ -211,11 +265,12 @@ export default defineComponent({
             <h5>Umgesetzte Therapien</h5>
             <div class="d-flex flex-column gap-2">
                 <div class="entity-card text-center mb-3 w-100">
-                    <h6>Gesamtverteilung der umgesetzten Therapien nach Wirkstoffklasse ({{ data.therapies.overallDistribution.total }})</h6>
+                    <h6>Gesamtverteilung der umgesetzten Therapien nach Wirkstoffklasse (N = {{ data.therapies.overallDistribution.total }})</h6>
 
                     <DQuerySummaryNested
                         ref="usedVNode"
                         :label="'Kategorie'"
+                        :placeholder="'Kategorie auswählen'"
                         :data="(data.therapies.overallDistribution.elements as any)"
                         :total="data.therapies.overallDistribution.total"
                     >
@@ -223,14 +278,16 @@ export default defineComponent({
                             <DKVChartTableSwitch
                                 :data="items"
                                 :clickable="true"
+                                :x-axis-label="'Anzahl umgesetzter Therapien [n]'"
+                                :y-axis-label="'Wirkstoffklasse bzw. Wirkstoff'"
                                 :columns="(level: number) => level === 0 && !id ? [
                                     {key: 'key', label: 'Wirkstoffklasse'},
-                                    {key: 'value', label: 'Anzahl [n]'},
-                                    {key: 'percent', label: 'Anteil [%]'},
+                                    {key: 'value', label: 'Anzahl umgesetzter Therapien [n]'},
+                                    {key: 'percent', label: 'Anteil umgesetzter Therapien [%]'},
                                 ] : [
                                     {key: 'key', label: 'Wirkstoff'},
                                     {key: 'value', label: 'Anzahl [n]'},
-                                    {key: 'percent', label: 'Anteil [%]'},
+                                    {key: 'percent', label: 'Anteil bzgl. Wirkstoffklasse [%]'},
                                 ]"
                                 @clicked="handleUsedClick"
                             />
@@ -241,47 +298,37 @@ export default defineComponent({
             <div class="d-flex flex-column gap-2">
                 <div class="entity-card text-center mb-3 w-100">
                     <h6>Mittlere Therapiedauer</h6>
-                    <DQuerySummaryGrouped
-                        :select-first="true"
-                        :items="data.therapies.meanDurations"
-                        :label="'Wirkstoffklasse'"
+                    <DQuerySummaryNested
+                        :label="'Kategorie'"
+                        :placeholder="'Kategorie auswählen'"
+                        :data="(meanDurationTree as any)"
                     >
-                        <template #default="{ item }">
+                        <template #default="{ items, id }">
                             <DKVChartTableSwitch
-                                :data="(item.value as any)"
+                                :data="items"
+                                :coding-verbose-label="true"
                                 :clickable="true"
+                                :x-axis-label="'Dauer in Wochen [Ø]'"
+                                :y-axis-label="'Wirkstoffklasse bzw. Wirkstoff'"
+                                :columns="(level: number) => level === 0 && !id ? [
+                                    {key: 'key', label: 'Wirkstoffklasse'},
+                                ] : [
+                                    {key: 'key', label: 'Wirkstoff'},
+                                    {key: 'value', label: 'Dauer in Wochen [Ø]'},
+                                ]"
                                 @clicked="handleUsedClick"
                             >
-                                <template #table="tableData">
-                                    <BTable
-                                        :items="tableData.data"
-                                        :fields="[
-                                            {
-                                                key: 'key',
-                                                label: 'Element',
-                                                thClass: 'text-left',
-                                                tdClass: 'text-left',
-                                            },
-                                            {
-                                                key: 'value',
-                                                label: 'Dauer in Wochen',
-                                                thClass: 'text-center',
-                                                tdClass: 'text-center',
-                                            }
-                                        ]"
-                                        outlined
-                                    >
-                                        <template #cell(key)="cell">
-                                            <DKVTableEntryKey :entity="(cell.item as any)" />
-                                        </template>
-                                        <template #cell(value)="cell">
-                                            {{ Number((cell.item as { value: number }).value).toFixed(2) }}
-                                        </template>
-                                    </BTable>
+                                <template #chart>
+                                    <DKVChart
+                                        :items="flattenMeanDurations(items)"
+                                        :coding-verbose-label="true"
+                                        :x-axis-label="'Dauer in Wochen [Ø]'"
+                                        :y-axis-label="'Wirkstoff'"
+                                    />
                                 </template>
                             </DKVChartTableSwitch>
                         </template>
-                    </DQuerySummaryGrouped>
+                    </DQuerySummaryNested>
                 </div>
             </div>
         </div>

--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryMedication.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryMedication.vue
@@ -9,10 +9,12 @@
 import { wrapFnWithBusyState } from '@authup/client-web-kit';
 import {
     type Coding,
+    type ConceptCountValue,
     DKVChart,
     DKVChartTableSwitch,
     DQuerySummaryGrouped,
     DQuerySummaryNested,
+    type KeyValueRecord,
     QueryEventBusEventName,
     injectQueryEventBus,
     toCodingGroup,
@@ -150,8 +152,10 @@ export default defineComponent({
             }));
         });
 
-        const flattenMeanDurations = (items: { children?: unknown[] }[]) => items.flatMap(
-            (item) => (Array.isArray(item.children) && item.children.length > 0 ?
+        const flattenMeanDurations = (
+            items: KeyValueRecord<Coding | Coding[], number | ConceptCountValue>[],
+        ) : KeyValueRecord<Coding | Coding[], number | ConceptCountValue>[] => items.flatMap(
+            (item) => (item.children && item.children.length > 0 ?
                 item.children :
                 [item]),
         );
@@ -250,7 +254,7 @@ export default defineComponent({
                                     {key: 'percent', label: 'Anteil Empfehlungen [%]'},
                                 ] : [
                                     {key: 'key', label: 'Wirkstoff'},
-                                    {key: 'value', label: 'Anzahl [n]'},
+                                    {key: 'value', label: 'Anzahl Empfehlungen [n]'},
                                     {key: 'percent', label: 'Anteil bzgl. Wirkstoffklasse [%]'},
                                 ]"
                                 @clicked="(keys: Coding[]) => handleRecommendationClick(keys, 'recommended')"
@@ -286,7 +290,7 @@ export default defineComponent({
                                     {key: 'percent', label: 'Anteil umgesetzter Therapien [%]'},
                                 ] : [
                                     {key: 'key', label: 'Wirkstoff'},
-                                    {key: 'value', label: 'Anzahl [n]'},
+                                    {key: 'value', label: 'Anzahl umgesetzter Therapien [n]'},
                                     {key: 'percent', label: 'Anteil bzgl. Wirkstoffklasse [%]'},
                                 ]"
                                 @clicked="handleUsedClick"

--- a/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryTumorDiagnostics.vue
+++ b/packages/mtb/src/runtime/components/core/query-summary/MQuerySummaryTumorDiagnostics.vue
@@ -106,10 +106,11 @@ export default defineComponent({
 
                 <div class="d-flex flex-column gap-2">
                     <div class="entity-card text-center mb-3">
-                        <h6>Tumor-Entitäten (ICD-10-GM)</h6>
+                        <h6>Verteilung nach ICD-10 GM (N = {{ data.overallDistributions.tumorEntities.total }})</h6>
                         <DQuerySummaryNested
                             ref="tumorEntitiesVNode"
                             :label="'Kategorie'"
+                            :placeholder="'Kategorie auswählen'"
                             :data="data.overallDistributions.tumorEntities.elements"
                             :total="data.overallDistributions.tumorEntities.total"
                             :key-verbose="true"
@@ -119,6 +120,8 @@ export default defineComponent({
                                     :coding-verbose-label="true"
                                     :data="items"
                                     :clickable="true"
+                                    :x-axis-label="'Anzahl [n]'"
+                                    :y-axis-label="'Tumorentität [ICD-10 GM] (Anteil [%])'"
                                     :columns="(level: number) => level === 0 && !id ? [
                                         {key: 'key', label: 'Tumorentität [ICD-10 GM]'},
                                         {key: 'value', label: 'Anzahl [n]'},
@@ -135,9 +138,10 @@ export default defineComponent({
                     </div>
 
                     <div class="entity-card text-center mb-3">
-                        <h6>Tumor-Morphologie (ICD-O-3-M)</h6>
+                        <h6>Verteilung nach ICD-O-3-M (N = {{ data.overallDistributions.tumorMorphologies.total }})</h6>
                         <DQuerySummaryNested
                             :label="'Kategorie'"
+                            :placeholder="'Kategorie auswählen'"
                             :data="data.overallDistributions.tumorMorphologies.elements"
                             :total="data.overallDistributions.tumorMorphologies.total"
                             :key-verbose="true"
@@ -146,12 +150,14 @@ export default defineComponent({
                                 <DKVChartTableSwitch
                                     :coding-verbose-label="true"
                                     :data="items"
+                                    :x-axis-label="'Anzahl [n]'"
+                                    :y-axis-label="'Tumormorphologie [ICD-O-3-M] (Anteil [%])'"
                                     :columns="(level: number) => level === 0 && !id ? [
-                                        {key: 'key', label: 'Tumor-Morphologie (ICD-O-3-M)'},
+                                        {key: 'key', label: 'Tumormorphologie [ICD-O-3-M]'},
                                         {key: 'value', label: 'Anzahl [n]'},
                                         {key: 'percent', label: 'Anteil [%]'},
                                     ] : [
-                                        {key: 'key', label: 'Tumor-Morphologie (ICD-O-3-M)'},
+                                        {key: 'key', label: 'Tumormorphologie [ICD-O-3-M]'},
                                         {key: 'value', label: 'Anzahl [n]'},
                                         {key: 'percent', label: 'Anteil [%]'},
                                     ]"
@@ -168,7 +174,7 @@ export default defineComponent({
             <h5>Gesamtverteilung</h5>
             <div class="d-flex flex-column gap-2">
                 <div class="entity-card text-center mb-3">
-                    <h6>Tumor-Entitäten (ICD-10-GM)</h6>
+                    <h6>Verteilung nach ICD-10 GM</h6>
                     <BPlaceholder
                         v-for="i in 5"
                         :key="i"
@@ -178,7 +184,7 @@ export default defineComponent({
                     />
                 </div>
                 <div class="entity-card text-center mb-3">
-                    <h6>Tumor-Morphologie (ICD-O-3-M)</h6>
+                    <h6>Verteilung nach ICD-O-3-M</h6>
                     <BPlaceholder
                         v-for="i in 5"
                         :key="i"

--- a/packages/mtb/src/runtime/components/core/search/MSearchForm.vue
+++ b/packages/mtb/src/runtime/components/core/search/MSearchForm.vue
@@ -8,7 +8,7 @@
 <script lang="ts">
 import {
     type Coding,
-    type ConnectionPeer, 
+    type ConnectionPeer,
     DLoadingButton,
     type FormTabInput,
     type ValueSetCoding,
@@ -31,9 +31,9 @@ import {
 } from '@vuecs/form-controls';
 import type { FormSelectOption } from '@vuecs/form-controls';
 import {
-    type PropType, 
-    reactive, 
-    toRef, 
+    type PropType,
+    reactive,
+    toRef,
     watch,
 } from 'vue';
 import { defineComponent, ref } from 'vue';
@@ -82,9 +82,9 @@ export default defineComponent({
         const mode = ref<QueryRequestMode>(QueryRequestMode.FEDERATED);
         const modeSites = ref<Coding[]>([]);
         const modeOptions : FormSelectOption[] = [
-            { id: QueryRequestMode.LOCAL, value: 'Lokal' },
-            { id: QueryRequestMode.FEDERATED, value: 'Föderiert' },
-            { id: QueryRequestMode.CUSTOM, value: 'Benutzerdefiniert' },
+            { id: QueryRequestMode.LOCAL, value: 'Lokal: eigener Standort' },
+            { id: QueryRequestMode.FEDERATED, value: 'Föderiert: alle Standorte' },
+            { id: QueryRequestMode.CUSTOM, value: 'Nutzer-definiert: gezielte Standort-Auswahl' },
         ];
 
         const busy = ref(false);
@@ -315,13 +315,13 @@ export default defineComponent({
         });
 
         const handleMedicationUpdated = ({
-            drugs, 
-            usage, 
-            combination, 
+            drugs,
+            usage,
+            combination,
         }: {
-            drugs: Coding[]; 
-            usage: string[]; 
-            combination: boolean 
+            drugs: Coding[];
+            usage: string[];
+            combination: boolean
         }) => {
             medicationDrugs.value = drugs;
             medicationUsage.value = usage;
@@ -362,52 +362,6 @@ export default defineComponent({
 <template>
     <div>
         <form>
-            <div>
-                <div class="d-flex flex-row align-items-center">
-                    <div>
-                        <h6 class="mb-0">
-                            <i class="fa fa-dna" /> Alteration
-                        </h6>
-                    </div>
-                    <div class="ms-auto">
-                        <button
-                            type="button"
-                            class="btn btn-dark btn-xs"
-                            @click.prevent="toggleExpanded('alteration')"
-                        >
-                            <i :class="{'fa fa-chevron-down': !expanded.alteration, 'fa fa-chevron-up': expanded.alteration}" />
-                        </button>
-                    </div>
-                </div>
-                <div
-                    v-show="expanded.alteration"
-                    class="mt-2"
-                >
-                    <DFormTabGroups
-                        v-model="mutations"
-                        :min-items="1"
-                        :max-items="6"
-                        :direction="'col'"
-                    >
-                        <template #default="props">
-                            <MMutationTabGroup
-                                :entity="props.data"
-                                @saved="props.saved"
-                            />
-                        </template>
-                    </DFormTabGroups>
-
-                    <VCFormInputCheckbox
-                        v-model="mutationsInCombination"
-                        :group-class="'form-switch'"
-                        :label="true"
-                        :label-content="'In Kombination?'"
-                    />
-                </div>
-            </div>
-
-            <hr>
-
             <div class="mb-3">
                 <div class="d-flex flex-row align-items-center">
                     <div>
@@ -515,6 +469,53 @@ export default defineComponent({
                             </template>
                         </VCFormGroup>
                     </div>
+                </div>
+            </div>
+
+            <hr>
+
+
+            <div>
+                <div class="d-flex flex-row align-items-center">
+                    <div>
+                        <h6 class="mb-0">
+                            <i class="fa fa-dna" /> Alteration
+                        </h6>
+                    </div>
+                    <div class="ms-auto">
+                        <button
+                            type="button"
+                            class="btn btn-dark btn-xs"
+                            @click.prevent="toggleExpanded('alteration')"
+                        >
+                            <i :class="{'fa fa-chevron-down': !expanded.alteration, 'fa fa-chevron-up': expanded.alteration}" />
+                        </button>
+                    </div>
+                </div>
+                <div
+                    v-show="expanded.alteration"
+                    class="mt-2"
+                >
+                    <DFormTabGroups
+                        v-model="mutations"
+                        :min-items="1"
+                        :max-items="6"
+                        :direction="'col'"
+                    >
+                        <template #default="props">
+                            <MMutationTabGroup
+                                :entity="props.data"
+                                @saved="props.saved"
+                            />
+                        </template>
+                    </DFormTabGroups>
+
+                    <VCFormInputCheckbox
+                        v-model="mutationsInCombination"
+                        :group-class="'form-switch'"
+                        :label="true"
+                        :label-content="'In Kombination?'"
+                    />
                 </div>
             </div>
 

--- a/packages/mtb/src/runtime/pages/query/[id]/index.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/index.vue
@@ -89,6 +89,11 @@ export default defineNuxtComponent({
                 urlSuffix: '/diagnostics',
             },
             {
+                name: 'Gen Alterationen',
+                icon: 'fas fa-dna',
+                urlSuffix: '/gene-alterations',
+            },
+            {
                 name: 'Medikation',
                 icon: 'fas fa-pills',
                 urlSuffix: '/medication',
@@ -97,11 +102,6 @@ export default defineNuxtComponent({
                 name: 'Therapie Responses',
                 icon: 'fas fa-comment-medical',
                 urlSuffix: '/therapy-responses',
-            },
-            {
-                name: 'Gen Alterationen',
-                icon: 'fas fa-dna',
-                urlSuffix: '/gene-alterations',
             },
             {
                 name: 'Überlebensbericht',


### PR DESCRIPTION
## Summary

Implements the ZPM feedback items (20.04.2026 list) for the MTB query summary views and search form.

### core
- `DKVChart` / `DKVChartTableSwitch`: optional `xAxisLabel` / `yAxisLabel` props (merged into chart options)
- `DQuerySummaryGrouped` / `DQuerySummaryNested`: configurable select `placeholder`
- `DQuerySummaryDemographics`: opt-in `withTotals` (N = …) and `withAxisLabels` props (defaults off, RD unchanged)

### mtb
- **Search form**: search mode texts ("Lokal: eigener Standort", "Föderiert: alle Standorte", "Nutzer-definiert: gezielte Standort-Auswahl"); section order aligned with tab order (Diagnose before Alteration)
- **Tabs**: "Gen Alterationen" moved directly after "Diagnose"
- **Demographie**: cohort totals and age chart axis labels enabled
- **Diagnose**: headings renamed to "Verteilung nach ICD-10 GM" / "Verteilung nach ICD-O-3-M" with N totals, "Kategorie auswählen" placeholders, column renames (Tumorentität/Tumormorphologie), axis labels
- **Gen-Alterationen distribution**: renamed to "TOP 20 der alterierten Gene (SNV/ CNV/ Fusion)", limited to 20 genes, no preselection ("Alterationsart auswählen"), N (alterierte Gene) subtitle, axis labels; gene column sortable
- **Medikation**: recommendation/therapy column labels precised (Anzahl/Anteil Empfehlungen, Anteil bzgl. Wirkstoffklasse), "Variante auswählen"/"Kategorie auswählen" placeholders, "Gesamtzahl Empfehlungen…: N = …" line, axis labels, empty-state for missing supporting variants; mean therapy durations restructured as expandable Wirkstoffklasse → Wirkstoff tree (no class-level duration, "Dauer in Wochen [Ø]")

### Not included (still open from the feedback list)
- Task 33: Hinweistext about entities aggregated into Oberkategorien
- Chart truncation warning text ("…da es zu Anzeigefehlern kommt") trim
- Y-axis label truncation direction / full text on hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional totals shown in demographic distribution headers
  * Configurable axis labels for charts
  * Configurable placeholders for selection dropdowns
  * Gene column in alterations table now sortable

* **Improvements**
  * Redesigned medication duration and distribution views with chart/table switch
  * Updated demographic and tumor-diagnostics section headings and labels
  * Reordered summary navigation and adjusted search form layout and option labels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->