### PR TITLE
fix(deps): bump @authup packages to v1.0.0-beta.52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,13 +48,13 @@
             }
         },
         "node_modules/@authup/access": {
-            "version": "1.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@authup/access/-/access-1.0.0-beta.51.tgz",
-            "integrity": "sha512-4ku+kz6R8tGdj5qLNw5T5Bqk3t2jKHBQXbUIFoNOgIPkxxE2KzgmlgU+A7pShHac90UlwrpeI/JVfOFsP4Df3g==",
+            "version": "1.0.0-beta.52",
+            "resolved": "https://registry.npmjs.org/@authup/access/-/access-1.0.0-beta.52.tgz",
+            "integrity": "sha512-MCaQiQcm+yp/AQE9j6+M+axdaJ9+K8mj63F9sCgYNCySqrAahMlNM2Xlehhi2jAcKBbmIailIomK4LRw3xF7OQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/errors": "^1.0.0-beta.51",
-                "@authup/kit": "^1.0.0-beta.51",
+                "@authup/errors": "^1.0.0-beta.52",
+                "@authup/kit": "^1.0.0-beta.52",
                 "@ucast/mongo2js": "^2.0.0",
                 "@validup/zod": "^0.3.3",
                 "smob": "^1.6.1",
@@ -66,18 +66,18 @@
             }
         },
         "node_modules/@authup/client-web-kit": {
-            "version": "1.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@authup/client-web-kit/-/client-web-kit-1.0.0-beta.51.tgz",
-            "integrity": "sha512-L9PNeAotzaXEzPRPAoyHOJeii11q6KHzEaVXZAF+BUztlFmueRzM9r7nxom+iM7+EMVcb4BGCzPRnvftmY1CHw==",
+            "version": "1.0.0-beta.52",
+            "resolved": "https://registry.npmjs.org/@authup/client-web-kit/-/client-web-kit-1.0.0-beta.52.tgz",
+            "integrity": "sha512-VBHMfLz5EtN/ogro1oQrVWDrsNKdT4w1+769SNca/CxeppQ03pCBrYjYR3qFjCEcX7AU5SqTYgtRdJCQR7yAcA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/access": "^1.0.0-beta.51",
-                "@authup/core-http-kit": "^1.0.0-beta.51",
-                "@authup/core-kit": "^1.0.0-beta.51",
-                "@authup/core-realtime-kit": "^1.0.0-beta.51",
-                "@authup/i18n": "^1.0.0-beta.51",
-                "@authup/kit": "^1.0.0-beta.51",
-                "@authup/specs": "^1.0.0-beta.51",
+                "@authup/access": "^1.0.0-beta.52",
+                "@authup/core-http-kit": "^1.0.0-beta.52",
+                "@authup/core-kit": "^1.0.0-beta.52",
+                "@authup/core-realtime-kit": "^1.0.0-beta.52",
+                "@authup/i18n": "^1.0.0-beta.52",
+                "@authup/kit": "^1.0.0-beta.52",
+                "@authup/specs": "^1.0.0-beta.52",
                 "@ilingo/validup": "^1.0.1",
                 "@posva/event-emitter": "^1.0.3",
                 "@validup/zod": "^0.3.3",
@@ -116,15 +116,15 @@
             }
         },
         "node_modules/@authup/client-web-kit-theme": {
-            "version": "1.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@authup/client-web-kit-theme/-/client-web-kit-theme-1.0.0-beta.51.tgz",
-            "integrity": "sha512-pj+0SFbka54h/aykmwxAAZudocgmqcF5Y6OHCleeTpgRd1M/xSO9mrV4oLWxR8Q1SLwV70SJMcimC/4Q1lVkpg==",
+            "version": "1.0.0-beta.52",
+            "resolved": "https://registry.npmjs.org/@authup/client-web-kit-theme/-/client-web-kit-theme-1.0.0-beta.52.tgz",
+            "integrity": "sha512-HpT+lWbo9S54aXKzAWbEh2pmq3aCsxcKc8ZmE7iAFobA7X5QteFk5SYPsuR6QV9xso0UWMPTd+LWEDY56lMYjg==",
             "license": "Apache-2.0",
             "engines": {
                 "node": "^22.13.0 || ^23.5.0 || >=24.0.0"
             },
             "peerDependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.51",
+                "@authup/client-web-kit": "^1.0.0-beta.52",
                 "@vuecs/core": "^3.4.0",
                 "@vuecs/design": "^1.0.8",
                 "@vuecs/theme-tailwind": "^6.3.0",
@@ -137,15 +137,15 @@
             }
         },
         "node_modules/@authup/client-web-nuxt": {
-            "version": "1.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@authup/client-web-nuxt/-/client-web-nuxt-1.0.0-beta.51.tgz",
-            "integrity": "sha512-4VcWt/tkKGVmTt6LnIxduRJA6JB9h8NO1qweb/FZEMKrrRxZfIbcAUYsSHOhOEEk86nIylXpiTNdlyPDVAtqeQ==",
+            "version": "1.0.0-beta.52",
+            "resolved": "https://registry.npmjs.org/@authup/client-web-nuxt/-/client-web-nuxt-1.0.0-beta.52.tgz",
+            "integrity": "sha512-82FZdY0H76c1ZCCW4xddgsjKbrPKumZrH1s9MmY9TYKLl7jT80XvTwx27Vghm14ZgYk/EsNVMTq5jbTT6vSsAQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/access": "^1.0.0-beta.51",
-                "@authup/client-web-kit": "^1.0.0-beta.51",
-                "@authup/kit": "^1.0.0-beta.51",
+                "@authup/access": "^1.0.0-beta.52",
+                "@authup/client-web-kit": "^1.0.0-beta.52",
+                "@authup/kit": "^1.0.0-beta.52",
                 "@nuxt/kit": "^4.0.0",
                 "pathtrace": "^2.2.0",
                 "smob": "^1.6.1"
@@ -159,15 +159,15 @@
             }
         },
         "node_modules/@authup/core-http-kit": {
-            "version": "1.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@authup/core-http-kit/-/core-http-kit-1.0.0-beta.51.tgz",
-            "integrity": "sha512-YB/0QvIyE/989yFiNhG42B3/U/zfFQAQWf2tjZh+8QaEygmrc0uF0uW68iZZpecqm7mt2dvP16OYFc48rA2ToA==",
+            "version": "1.0.0-beta.52",
+            "resolved": "https://registry.npmjs.org/@authup/core-http-kit/-/core-http-kit-1.0.0-beta.52.tgz",
+            "integrity": "sha512-EneuExXOZ7jgyneKB/6Q7uFei0OAKV+lXaRHTQloSjMs+g7t97xiziW5hlWcbLPKSieyHz60tSEOYvy5To47yg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/access": "^1.0.0-beta.51",
-                "@authup/core-kit": "^1.0.0-beta.51",
-                "@authup/kit": "^1.0.0-beta.51",
-                "@authup/specs": "^1.0.0-beta.51",
+                "@authup/access": "^1.0.0-beta.52",
+                "@authup/core-kit": "^1.0.0-beta.52",
+                "@authup/kit": "^1.0.0-beta.52",
+                "@authup/specs": "^1.0.0-beta.52",
                 "@hapic/oauth2": "^4.0.1",
                 "@posva/event-emitter": "^1.0.3",
                 "hapic": "^3.0.1",
@@ -204,14 +204,14 @@
             }
         },
         "node_modules/@authup/core-kit": {
-            "version": "1.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@authup/core-kit/-/core-kit-1.0.0-beta.51.tgz",
-            "integrity": "sha512-nS5DtQ24LCsrDH7gV9AtqNivjEIxiuOHrW0EuIQcSnjfwhjx35wLFncJM3xyuHUr2C6ezPfujKWgfpgkyIgorg==",
+            "version": "1.0.0-beta.52",
+            "resolved": "https://registry.npmjs.org/@authup/core-kit/-/core-kit-1.0.0-beta.52.tgz",
+            "integrity": "sha512-uMFa2uzazv5iMHpo7PJvmbboSM68TlDebf9BWKnkU8SnunIzj4kZeeeaYc/6251AMuIza9Za/FNEBd8gpTNRKg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/errors": "^1.0.0-beta.51",
-                "@authup/kit": "^1.0.0-beta.51",
-                "@authup/specs": "^1.0.0-beta.51",
+                "@authup/errors": "^1.0.0-beta.52",
+                "@authup/kit": "^1.0.0-beta.52",
+                "@authup/specs": "^1.0.0-beta.52",
                 "@validup/zod": "^0.3.3",
                 "validup": "^0.5.1",
                 "zod": "^4.4.3"
@@ -221,12 +221,12 @@
             }
         },
         "node_modules/@authup/core-realtime-kit": {
-            "version": "1.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@authup/core-realtime-kit/-/core-realtime-kit-1.0.0-beta.51.tgz",
-            "integrity": "sha512-0/+YKXGFrQc1dKm71xTBB7xOhnpA/1NsY2ZJipOPqpkryWvcFw1vzS1PixexezowwiyY17w/FrdR2T2aGUuDEw==",
+            "version": "1.0.0-beta.52",
+            "resolved": "https://registry.npmjs.org/@authup/core-realtime-kit/-/core-realtime-kit-1.0.0-beta.52.tgz",
+            "integrity": "sha512-v1nm+Zq7tz+ngEiBoRAG3cdZiI+vg3xYDv4b5MKfK1JXCWkOBhrvsTLxswiTExkXWqr2wWXnG5N8JXaHpYN5TA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/kit": "^1.0.0-beta.51"
+                "@authup/kit": "^1.0.0-beta.52"
             },
             "engines": {
                 "node": "^22.13.0 || ^23.5.0 || >=24.0.0"
@@ -236,9 +236,9 @@
             }
         },
         "node_modules/@authup/errors": {
-            "version": "1.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@authup/errors/-/errors-1.0.0-beta.51.tgz",
-            "integrity": "sha512-vFqWnuQYMJlHh+pP+EloYqrIGOXjZLWHjL0wWyqiw4nRtOQJJTv7KGlPH3DGqDDAvOSHQ0RKUNtB8vagKSa05w==",
+            "version": "1.0.0-beta.52",
+            "resolved": "https://registry.npmjs.org/@authup/errors/-/errors-1.0.0-beta.52.tgz",
+            "integrity": "sha512-Dm7DOI+P8MQNbJUdT/hhquZhpKnhHTuyDs4TIVzyi8hTvSI8ZMMRGHKbg1SQ2bQ/hCfl0q5EHJX7cgfmKo06gQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ebec/core": "^1.1.0",
@@ -249,12 +249,12 @@
             }
         },
         "node_modules/@authup/i18n": {
-            "version": "1.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@authup/i18n/-/i18n-1.0.0-beta.51.tgz",
-            "integrity": "sha512-dkL3bmRqigCd4s/njPt/Am9ju9tHxNj1HI9O5Hm86OTuEWf7cHnkcQaO3lX898eQOmKPGNRz+ALPjW7/C7RPDQ==",
+            "version": "1.0.0-beta.52",
+            "resolved": "https://registry.npmjs.org/@authup/i18n/-/i18n-1.0.0-beta.52.tgz",
+            "integrity": "sha512-nkRzFoBFYUDjEuBVixWvtRZm55CKt80MxY9/Fi4mz+yFQ5Li+WZN6xpqRh6kqwgY+BjoYPc77qD0UDGSY3s2Vg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/errors": "^1.0.0-beta.51",
+                "@authup/errors": "^1.0.0-beta.52",
                 "ilingo": "^6.0.0"
             },
             "engines": {
@@ -270,13 +270,13 @@
             }
         },
         "node_modules/@authup/kit": {
-            "version": "1.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@authup/kit/-/kit-1.0.0-beta.51.tgz",
-            "integrity": "sha512-vZ+s+cBa2o8l+CF7Oxxs64VfpUixHEk4kcQP1Zbu88e+mL9I25IzHKpT6bBPSv+h1Q8Xi1fFWGWf9Na13nQHuQ==",
+            "version": "1.0.0-beta.52",
+            "resolved": "https://registry.npmjs.org/@authup/kit/-/kit-1.0.0-beta.52.tgz",
+            "integrity": "sha512-P/jkuOJvdKgNSI4LjkaevZ/sWqeSy3g6oBlV26VLcD955E2NCv7HCLvsCu7wQrahDZFbACSja+BMtolP+Oqelw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "destr": "^2.0.3",
-                "nanoid": "^5.1.11"
+                "nanoid": "^5.1.16"
             },
             "engines": {
                 "node": "^22.13.0 || ^23.5.0 || >=24.0.0"
@@ -301,13 +301,13 @@
             }
         },
         "node_modules/@authup/specs": {
-            "version": "1.0.0-beta.51",
-            "resolved": "https://registry.npmjs.org/@authup/specs/-/specs-1.0.0-beta.51.tgz",
-            "integrity": "sha512-vLbZcftML+va0WRf55bLxA6BBw4pmQUxvkZdm9jFBIxhI6wsewgT48NMMm1+ga+KZDfvtLXmAB6rTrT/FenAjg==",
+            "version": "1.0.0-beta.52",
+            "resolved": "https://registry.npmjs.org/@authup/specs/-/specs-1.0.0-beta.52.tgz",
+            "integrity": "sha512-rQK33CMw6jA1NdIgy0IqiYZfbGNvVpmqDkDT+/DtUHJVP0Bxz5dhPElKybCaJlpvmB04NH1wFriqBCX9U+L/pw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/errors": "^1.0.0-beta.51",
-                "@authup/kit": "^1.0.0-beta.51",
+                "@authup/errors": "^1.0.0-beta.52",
+                "@authup/kit": "^1.0.0-beta.52",
                 "pathtrace": "^2.2.0",
                 "smob": "^1.6.1"
             },
@@ -18053,6 +18053,14 @@
                 "text-decoder": "^1.1.0"
             }
         },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
         "node_modules/string-argv": {
             "version": "0.3.2",
             "dev": true,
@@ -18101,14 +18109,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/string_decoder": {
-            "version": "1.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/strip-ansi": {
@@ -20971,8 +20971,8 @@
             "version": "1.10.1",
             "license": "MIT",
             "dependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.51",
-                "@authup/core-kit": "^1.0.0-beta.51",
+                "@authup/client-web-kit": "^1.0.0-beta.52",
+                "@authup/core-kit": "^1.0.0-beta.52",
                 "@dnpm-dip/core": "^1.11.0",
                 "@dnpm-dip/kit": "^1.10.0",
                 "@nuxt/kit": "^4.4.5",
@@ -21639,8 +21639,8 @@
                 "ufo": "^1.6.2"
             },
             "devDependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.51",
-                "@authup/core-http-kit": "^1.0.0-beta.51",
+                "@authup/client-web-kit": "^1.0.0-beta.52",
+                "@authup/core-http-kit": "^1.0.0-beta.52",
                 "@ilingo/validup": "^1.0.1",
                 "@ilingo/validup-vue": "^1.0.1",
                 "@ilingo/vue": "^6.0.0",
@@ -21669,8 +21669,8 @@
                 "zod": "^4.3.6"
             },
             "peerDependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.51",
-                "@authup/core-http-kit": "^1.0.0-beta.51",
+                "@authup/client-web-kit": "^1.0.0-beta.52",
+                "@authup/core-http-kit": "^1.0.0-beta.52",
                 "@ilingo/validup": "^1.x",
                 "@ilingo/validup-vue": "^1.x",
                 "@ilingo/vue": "^6.x",
@@ -21725,7 +21725,7 @@
             "version": "1.35.0",
             "license": "MIT",
             "dependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.51",
+                "@authup/client-web-kit": "^1.0.0-beta.52",
                 "@dnpm-dip/core": "^1.35.0",
                 "@dnpm-dip/kit": "^1.28.1",
                 "@nuxt/kit": "^4.4.5"
@@ -22400,12 +22400,12 @@
             "name": "@dnpm-dip/portal",
             "version": "1.34.0",
             "devDependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.51",
-                "@authup/client-web-kit-theme": "^1.0.0-beta.51",
-                "@authup/client-web-nuxt": "^1.0.0-beta.51",
-                "@authup/core-http-kit": "^1.0.0-beta.51",
-                "@authup/core-kit": "^1.0.0-beta.51",
-                "@authup/kit": "^1.0.0-beta.51",
+                "@authup/client-web-kit": "^1.0.0-beta.52",
+                "@authup/client-web-kit-theme": "^1.0.0-beta.52",
+                "@authup/client-web-nuxt": "^1.0.0-beta.52",
+                "@authup/core-http-kit": "^1.0.0-beta.52",
+                "@authup/core-kit": "^1.0.0-beta.52",
+                "@authup/kit": "^1.0.0-beta.52",
                 "@dnpm-dip/core": "^1.35.0",
                 "@dnpm-dip/kit": "^1.28.1",
                 "@dnpm-dip/mtb": "^1.35.0",
@@ -22473,7 +22473,7 @@
             "version": "1.34.0",
             "license": "MIT",
             "dependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.51",
+                "@authup/client-web-kit": "^1.0.0-beta.52",
                 "@dnpm-dip/core": "^1.35.0",
                 "@dnpm-dip/kit": "^1.28.1",
                 "@nuxt/kit": "^4.4.5"
@@ -23146,7 +23146,7 @@
             "version": "1.35.0",
             "license": "MIT",
             "dependencies": {
-                "@authup/client-web-kit-theme": "^1.0.0-beta.51",
+                "@authup/client-web-kit-theme": "^1.0.0-beta.52",
                 "@vuecs/design": "^1.0.8",
                 "@vuecs/theme-tailwind": "^6.1.1"
             },

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -30,8 +30,8 @@
         "test:watch": "vitest watch"
     },
     "dependencies": {
-        "@authup/core-kit": "^1.0.0-beta.51",
-        "@authup/client-web-kit": "^1.0.0-beta.51",
+        "@authup/core-kit": "^1.0.0-beta.52",
+        "@authup/client-web-kit": "^1.0.0-beta.52",
         "@dnpm-dip/core": "^1.11.0",
         "@dnpm-dip/kit": "^1.10.0",
         "@nuxt/kit": "^4.4.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,8 +47,8 @@
         "ufo": "^1.6.2"
     },
     "devDependencies": {
-        "@authup/core-http-kit": "^1.0.0-beta.51",
-        "@authup/client-web-kit": "^1.0.0-beta.51",
+        "@authup/core-http-kit": "^1.0.0-beta.52",
+        "@authup/client-web-kit": "^1.0.0-beta.52",
         "chart.js": "^4.5.1",
         "@ilingo/validup": "^1.0.1",
         "@ilingo/validup-vue": "^1.0.1",
@@ -77,8 +77,8 @@
         "zod": "^4.3.6"
     },
     "peerDependencies": {
-        "@authup/core-http-kit": "^1.0.0-beta.51",
-        "@authup/client-web-kit": "^1.0.0-beta.51",
+        "@authup/core-http-kit": "^1.0.0-beta.52",
+        "@authup/client-web-kit": "^1.0.0-beta.52",
         "chart.js": "^4.4.3",
         "@ilingo/validup": "^1.x",
         "@ilingo/validup-vue": "^1.x",

--- a/packages/mtb/package.json
+++ b/packages/mtb/package.json
@@ -29,7 +29,7 @@
         "lint": "eslint ."
     },
     "dependencies": {
-        "@authup/client-web-kit": "^1.0.0-beta.51",
+        "@authup/client-web-kit": "^1.0.0-beta.52",
         "@dnpm-dip/core": "^1.35.0",
         "@dnpm-dip/kit": "^1.28.1",
         "@nuxt/kit": "^4.4.5"

--- a/packages/portal/components/header.vue
+++ b/packages/portal/components/header.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
 import { storeToRefs } from 'pinia';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { VCNavItems } from '@vuecs/navigation';
 import { VCIcon } from '@vuecs/icon';
-import { injectStore } from '@authup/client-web-kit';
+import { StoreAuthStatus, injectStore } from '@authup/client-web-kit';
 import { useColorMode } from '#imports';
 import { defineNuxtComponent } from '#app';
 import { LayoutTopNavigationRegistryId, injectNavigation } from '../core';
@@ -17,7 +17,9 @@ export default defineNuxtComponent({
     },
     setup() {
         const store = injectStore();
-        const { loggedIn, user } = storeToRefs(store);
+        const { status, user } = storeToRefs(store);
+
+        const authenticated = computed(() => status.value === StoreAuthStatus.AUTHENTICATED);
 
         const displayNav = ref(false);
 
@@ -28,7 +30,7 @@ export default defineNuxtComponent({
         const navigation = injectNavigation();
         const topItems = () => navigation.getTopItems();
         const topItemsWatch = [
-            () => store.loggedIn,
+            () => store.status,
             () => store.userId,
         ];
 
@@ -38,7 +40,7 @@ export default defineNuxtComponent({
         };
 
         return {
-            loggedIn,
+            authenticated,
             user,
             toggleNav,
             displayNav,
@@ -101,7 +103,7 @@ export default defineNuxtComponent({
                                 <VCIcon :name="isDark ? 'fa6-solid:sun' : 'fa6-solid:moon'" />
                             </button>
                         </li>
-                        <template v-if="loggedIn && user">
+                        <template v-if="authenticated && user">
                             <li class="vc-nav-item">
                                 <a
                                     href="javascript:void(0)"

--- a/packages/portal/components/sidebar.vue
+++ b/packages/portal/components/sidebar.vue
@@ -5,7 +5,7 @@ import type { NavigationResolverContext } from '@vuecs/navigation';
 import { VCNavItems } from '@vuecs/navigation';
 import { VCCountdown } from '@vuecs/countdown';
 import { VCIcon } from '@vuecs/icon';
-import { injectStore } from '@authup/client-web-kit';
+import { StoreAuthStatus, injectStore } from '@authup/client-web-kit';
 import { defineNuxtComponent } from '#app';
 import { LayoutTopNavigationRegistryId, injectNavigation } from '../core';
 
@@ -17,7 +17,9 @@ export default defineNuxtComponent({
     },
     setup() {
         const store = injectStore();
-        const { loggedIn, accessTokenExpireDate: tokenExpireDate } = storeToRefs(store);
+        const { status, accessTokenExpireDate: tokenExpireDate } = storeToRefs(store);
+
+        const authenticated = computed(() => status.value === StoreAuthStatus.AUTHENTICATED);
 
         const tokenExpiresIn = computed(() => {
             if (!tokenExpireDate.value) {
@@ -35,12 +37,12 @@ export default defineNuxtComponent({
             return navigation.getSideItems(activeTopName);
         };
         const sideItemsWatch = [
-            () => store.loggedIn,
+            () => store.status,
             () => store.userId,
         ];
 
         return {
-            loggedIn,
+            authenticated,
             tokenExpiresIn,
             sideItems,
             sideItemsWatch,
@@ -60,7 +62,7 @@ export default defineNuxtComponent({
             />
             <div class="mt-auto">
                 <div
-                    v-if="loggedIn"
+                    v-if="authenticated"
                     class="font-light flex flex-col ms-3 me-3 mb-3 mt-auto text-sm"
                     style="color: var(--dnpm-chrome-fg-muted)"
                 >

--- a/packages/portal/core/navigation/module.ts
+++ b/packages/portal/core/navigation/module.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Store } from '@authup/client-web-kit';
+import { StoreAuthStatus } from '@authup/client-web-kit';
 import type { IdentityPolicyData } from '@authup/access';
 import { BuiltInPolicyType, PolicyData } from '@authup/access';
 import type { NavigationItemMeta } from '@dnpm-dip/core';
@@ -120,7 +121,7 @@ export class Navigation {
             return item;
         }
 
-        const { loggedIn } = this.store;
+        const authenticated = this.store.status === StoreAuthStatus.AUTHENTICATED;
         let identity: IdentityPolicyData | undefined;
         if (this.store.userId) {
             identity = {
@@ -132,7 +133,7 @@ export class Navigation {
         if (
             typeof item.meta.requireLoggedIn !== 'undefined' &&
             item.meta.requireLoggedIn &&
-            !loggedIn
+            !authenticated
         ) {
             return undefined;
         }
@@ -140,7 +141,7 @@ export class Navigation {
         if (
             typeof item.meta.requireLoggedOut !== 'undefined' &&
             item.meta.requireLoggedOut &&
-            loggedIn
+            authenticated
         ) {
             return undefined;
         }

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -17,12 +17,12 @@
         "start": "node .output/server/index.mjs"
     },
     "devDependencies": {
-        "@authup/client-web-kit": "^1.0.0-beta.51",
-        "@authup/client-web-kit-theme": "^1.0.0-beta.51",
-        "@authup/client-web-nuxt": "^1.0.0-beta.51",
-        "@authup/core-http-kit": "^1.0.0-beta.51",
-        "@authup/core-kit": "^1.0.0-beta.51",
-        "@authup/kit": "^1.0.0-beta.51",
+        "@authup/client-web-kit": "^1.0.0-beta.52",
+        "@authup/client-web-kit-theme": "^1.0.0-beta.52",
+        "@authup/client-web-nuxt": "^1.0.0-beta.52",
+        "@authup/core-http-kit": "^1.0.0-beta.52",
+        "@authup/core-kit": "^1.0.0-beta.52",
+        "@authup/kit": "^1.0.0-beta.52",
         "@dnpm-dip/core": "^1.35.0",
         "@dnpm-dip/kit": "^1.28.1",
         "@dnpm-dip/mtb": "^1.35.0",

--- a/packages/rd/package.json
+++ b/packages/rd/package.json
@@ -28,7 +28,7 @@
         "lint": "eslint ."
     },
     "dependencies": {
-        "@authup/client-web-kit": "^1.0.0-beta.51",
+        "@authup/client-web-kit": "^1.0.0-beta.52",
         "@dnpm-dip/core": "^1.35.0",
         "@dnpm-dip/kit": "^1.28.1",
         "@nuxt/kit": "^4.4.5"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -49,7 +49,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@authup/client-web-kit-theme": "^1.0.0-beta.51",
+        "@authup/client-web-kit-theme": "^1.0.0-beta.52",
         "@vuecs/design": "^1.0.8",
         "@vuecs/theme-tailwind": "^6.1.1"
     },


### PR DESCRIPTION
## Summary

Lockstep bump of every `@authup/*` dependency from `^1.0.0-beta.51` to `^1.0.0-beta.52` (6 manifests + lockfile; `packages/core`'s dependency/peer pairs kept aligned), plus adoption of the kit store's new auth phase model that release ships (authup/authup#3220):

- `loggedIn` (deprecated in beta.52 — a bare access-token-presence flag) is replaced with `status === StoreAuthStatus.AUTHENTICATED` (presence-derived: token + realm + user) in the portal navigation reducer, header and sidebar; the nav-resolver watch sources move from `() => store.loggedIn` to `() => store.status`.
- No other deprecated store surface was in use (`setUser`, `accessTokenExpireDate` reads and the page-meta `REQUIRED_LOGGED_IN/OUT` keys are not deprecated).

Behavior note from the upstream release: a login whose introspection/userinfo lookup fails now rejects with **no session left behind** (previously a token-only half-session remained). The portal has no direct `store.login()` call site — the authorization-code exchange runs through `@authup/client-web-nuxt`'s interceptor, which already strips `code`/`state` on failure — so no further change is needed.

## Verification

- `npm run build -w packages/portal` (includes `nuxt typecheck`) passes against beta.52
- ESLint clean on the touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication state detection across portal navigation, headers, and sidebars.
  - Ensured user menus and authentication-dependent navigation update reliably when session status changes.

- **Chores**
  - Updated Authup packages to beta.52 across portal, admin, core, MTB, RD, and theme components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->