### PR TITLE
feat(mtb): render complete patient record per ETL schema

### DIFF
--- a/packages/core/src/components/core/patient/Patient.vue
+++ b/packages/core/src/components/core/patient/Patient.vue
@@ -35,6 +35,13 @@ export default defineComponent({
                     {{ entity.birthDate }}
                 </DFact>
                 <DFact
+                    v-if="entity.age"
+                    label="Alter"
+                    icon="fa6-solid:hourglass-half"
+                >
+                    {{ entity.age.value }} {{ entity.age.unit }}
+                </DFact>
+                <DFact
                     v-if="entity.dateOfDeath"
                     label="Todestag"
                     icon="fa6-solid:skull"
@@ -54,6 +61,13 @@ export default defineComponent({
                     icon="fa6-solid:heart-pulse"
                 >
                     <DCodingText :entity="entity.vitalStatus" />
+                </DFact>
+                <DFact
+                    v-if="entity.healthInsurance"
+                    label="Krankenversicherung"
+                    icon="fa6-solid:id-card"
+                >
+                    <DCodingText :entity="entity.healthInsurance.type" />
                 </DFact>
                 <DFact
                     v-if="entity.address"

--- a/packages/core/src/domains/patient/types.ts
+++ b/packages/core/src/domains/patient/types.ts
@@ -19,6 +19,13 @@ export type Patient = {
     gender: Coding<'male' | 'female' | 'other' | 'unknown'>
     birthDate: string,
     dateOfDeath?: string,
+    /**
+     * @see https://github.com/KohlbacherLab/dnpm-dip-core/blob/main/src/main/scala/de/dnpm/dip/model/Quantity.scala
+     */
+    age?: {
+        value: number,
+        unit: string
+    },
     managingSite?: Coding,
     vitalStatus?: Coding,
     healthInsurance?: PatientInsurance,

--- a/packages/mtb/src/runtime/components/core/MNGSReportSNV.vue
+++ b/packages/mtb/src/runtime/components/core/MNGSReportSNV.vue
@@ -53,7 +53,7 @@ export default defineComponent({
                     <strong>Lokalisierung</strong>
                     <DCodingCommaList :items="entity.localization" />
                 </div>
-                <div>
+                <div v-if="entity.interpretation">
                     <strong>Interpretation</strong> <small>{{ entity.interpretation.display }}</small>
                 </div>
                 <div>

--- a/packages/mtb/src/runtime/domains/patient/types.ts
+++ b/packages/mtb/src/runtime/domains/patient/types.ts
@@ -1,6 +1,7 @@
 import type {
     Coding,
     ExternalId,
+    GeneAlterationReference,
     History,
     Patient,
     PatientMatchBase,
@@ -9,26 +10,40 @@ import type {
 } from '@dnpm-dip/core';
 import type { QueryCriteria } from '../query';
 
+/**
+ * Reference to an external system-qualified resource (e.g. study or publication).
+ *
+ * @see https://github.com/dnpm-dip/mtb-model — Study_Reference / Publication_Reference
+ */
+export type SystemReference = {
+    id: string,
+    system: string,
+    display?: string,
+    type?: string
+};
+
 export type PatientMatch = PatientMatchBase<QueryCriteria>;
 
 export type NGSReportSNV = {
     id: string,
-    patient: Record<string, any>,
+    patient: Reference,
     externalIds?: ExternalId[],
     chromosome: Coding,
     localization?: Coding[],
     gene: Coding,
     transcriptId: Coding,
+    exonId?: string,
     position: {
-        start: number
+        start: number,
+        end?: number
     },
     altAllele: string,
     refAllele: string,
     dnaChange: string,
-    proteinChange: string,
+    proteinChange?: string,
     readDepth: number,
     allelicFrequency: number,
-    interpretation: Coding
+    interpretation?: Coding
 };
 
 export type NGSReportCNV = {
@@ -113,6 +128,35 @@ export type NGSRNAFusion = {
     reportedNumReads: number
 };
 
+export type TumorCellContent = {
+    id: string,
+    patient: Reference,
+    specimen: Reference,
+    method: Coding,
+    value: number
+};
+
+/**
+ * @see https://github.com/dnpm-dip/mtb-model — RNASeq
+ */
+export type NGSRNASeq = {
+    id: string,
+    patient: Reference,
+    variant: Reference,
+    rawCounts: number,
+    transcriptsPerMillion: number,
+    librarySize?: number,
+    cohortRanking?: number,
+    tissueCorrectedExpression?: boolean,
+    gene?: Coding,
+    transcriptId?: {
+        value: string,
+        system?: string
+    },
+    localization?: Coding[],
+    externalIds?: ExternalId[]
+};
+
 /**
  * @see https://github.com/KohlbacherLab/dnpm-dip-mtb-model/blob/main/dto_model/src/main/scala/de/dnpm/dip/mtb/model/NGSReport.scala
  */
@@ -122,26 +166,33 @@ export type NgsReportResults = {
     dnaFusions: NGSDNAFusion[],
     hrdScore?: NGSHRDScore,
     rnaFusions: NGSRNAFusion[],
-    rnaSeqs: Record<string, any>[],
+    rnaSeqs: NGSRNASeq[],
     simpleVariants: NGSReportSNV[],
     tmb?: {
         [key: string]: any,
+        interpretation?: Coding,
         value: {
             value: number,
-            unit: string,
+            unit?: string,
         }
     },
-    tumorCellContent?: {
-        [key: string]: any,
-        value: number
-    }
+    tumorCellContent?: TumorCellContent
+};
+
+export type NgsReportMetadata = {
+    kitManufacturer: string,
+    kitType: string,
+    pipeline: string,
+    referenceGenome: string,
+    sequencer: string
 };
 
 export type SomaticNGSReport = {
     id: string,
     issuedOn: string,
-    metadata: Record<string, any>[],
+    metadata: NgsReportMetadata[],
     patient: Reference,
+    specimen: Reference,
     results: NgsReportResults,
     type: Coding<string>
 };
@@ -156,14 +207,14 @@ type Episode = {
 };
 
 type DiagnosisType = {
-    value: Coding[],
+    value: Coding,
     date: string
 };
 
 type TumorStaging = {
     date: string,
     method: Coding,
-    tmnClassification?: {
+    tnmClassification?: {
         tumor: Coding,
         nodes: Coding,
         metastasis: Coding,
@@ -180,27 +231,35 @@ type Diagnosis = {
     id: string,
     patient: Reference,
     recordedOn: string,
-    /**
-     * todo: new type
-     */
     type: History<DiagnosisType>,
-    /**
-     * todo: new type
-     */
     germlineCodes?: Coding[],
     code: Coding,
     topography: Coding,
     staging?: History<TumorStaging>,
     grading?: History<TumorGrading>,
     guidelineTreatmentStatus?: Coding,
-    /**
-     * todo: new prop
-     */
     histology?: Reference[],
-    /**
-     * todo: new prop
-     */
     notes?: string[]
+};
+
+type FamilyMemberHistory = {
+    id: string,
+    patient: Reference,
+    relationship: Coding
+};
+
+/**
+ * Microsatellite-instability finding.
+ *
+ * @see https://github.com/dnpm-dip/mtb-model — MSI
+ */
+type MSI = {
+    id: string,
+    patient: Reference,
+    specimen: Reference,
+    method: Coding,
+    interpretation: Coding,
+    value: number
 };
 
 /**
@@ -211,13 +270,7 @@ type SystemicTherapy = {
     patient: Reference,
     reason?: Reference,
     therapyLine?: number,
-    /**
-     * todo new prop
-     */
     intent?: Coding,
-    /**
-     * todo new prop
-     */
     category?: Coding,
     basedOn?: Reference,
     recordedOn: string,
@@ -272,9 +325,9 @@ type HistologyReportResults = {
         patient: Reference,
         specimen: Reference,
         value: Coding,
-        notes?: string
+        note?: string
     }
-    tumorCellContent?: Record<string, any>
+    tumorCellContent?: TumorCellContent
 };
 
 type HistologyReport = {
@@ -291,6 +344,7 @@ type ProteinExpression = {
     protein: Coding,
     value: Coding,
     tpsScore?: number,
+    cpsScore?: number,
     icScore?: Coding,
     tcScore?: Coding,
 };
@@ -307,29 +361,26 @@ type IHCReport = {
 };
 
 type LevelOfEvidence = {
-    grading?: Coding,
+    grading: Coding,
     addendums?: Coding[],
-    publications?: { pmid: string, doi: string }[]
+    publications?: SystemReference[]
 };
 
 type Recommendation = {
     levelOfEvidence?: LevelOfEvidence,
+    supportingVariants?: GeneAlterationReference[],
+    supportingFindings?: Reference[],
 };
 
 type MedicationRecommendation = Recommendation & {
     id: string,
     patient: Reference,
-    reason: Reference,
+    reason?: Reference,
     priority: Coding,
     issuedOn: string,
     medication: Coding[],
     category?: Coding[],
-    useType?: Coding,
-    supportingVariants: {
-        id: string, 
-        display: string, 
-        type: string 
-    }[]
+    useType?: Coding
 };
 
 type GeneticCounselingRecommendation = {
@@ -339,18 +390,14 @@ type GeneticCounselingRecommendation = {
     reason: Coding
 };
 
-type StudyEnrollmentRecommendation = {
+type StudyEnrollmentRecommendation = Recommendation & {
     id: string,
-    patient: Patient,
-    reason: Reference,
+    patient: Reference,
+    reason?: Reference,
     issuedOn: string,
-    levelOfEvidence?: Coding,
-    supportingVariants: {
-        id: string, 
-        display: string, 
-        type: string 
-    }[],
-    studyIds: string[]
+    priority: Coding,
+    medication?: Coding[],
+    study: SystemReference[]
 };
 
 type ProcedureRecommendation = Recommendation & {
@@ -359,8 +406,7 @@ type ProcedureRecommendation = Recommendation & {
     reason?: Reference,
     issuedOn: string,
     priority: Coding,
-    code: Coding,
-    supportingVariants?: Reference[]
+    code: Coding
 };
 
 type HistologyReevaluationRequest = {
@@ -380,22 +426,16 @@ type RebiopsyRequest = {
 type CarePlan = {
     id: string,
     patient: Reference,
-    reason: Reference,
+    reason?: Reference,
     issuedOn: string,
+    boardType?: Coding,
     noSequencingPerformedReason?: Coding,
     recommendationsMissingReason?: Coding,
     notes?: string[],
     medicationRecommendations?: MedicationRecommendation[],
     geneticCounselingRecommendation?: GeneticCounselingRecommendation,
-    /**
-     * todo: new prop
-     */
     procedureRecommendations?: ProcedureRecommendation[],
     studyEnrollmentRecommendations?: StudyEnrollmentRecommendation[],
-
-    /**
-     * todo: new prop
-     */
     histologyReevaluationRequests?: HistologyReevaluationRequest[],
     rebiopsyRequests?: RebiopsyRequest[]
 };
@@ -404,19 +444,13 @@ type Claim = {
     id: string,
     patient: Reference,
     recommendation: Reference,
-    /**
-     * todo: new prop
-     */
     requestedMedication?: Coding[],
     issuedOn: string,
-    /**
-     * todo: new prop
-     */
     stage?: Coding,
     /**
-     * @deprecated
+     * @deprecated no longer part of the ETL schema; kept for backwards compatibility.
      */
-    status: Coding
+    status?: Coding
 };
 
 type ClaimResponse = {
@@ -433,6 +467,7 @@ type Response = {
     patient: Reference,
     therapy: Reference,
     effectiveDate: string,
+    method?: Coding,
     value: Coding
 };
 
@@ -453,28 +488,64 @@ type MolecularDiagnosticReport = {
     results?: string[]
 };
 
+export type MVHSubmissionType = 'initial' | 'correction' | 'test' | 'addition' | 'followup';
+
+export type ModelProjectConsentPurpose = 'case-identification' | 'reidentification' | 'sequencing';
+
+export type ConsentProvisionType = 'permit' | 'deny';
+
+export type ResearchConsentMissingReason =    | 'organizational-issues' |
+    'technical-issues' |
+    'patient-inability' |
+    'other-patient-reason' |
+    'consent-not-returned' |
+    'patient-refusal';
+
+type ConsentProvision = {
+    date: string,
+    purpose: ModelProjectConsentPurpose | string,
+    type: ConsentProvisionType | string
+};
+
+type ModelProjectConsent = {
+    version: string,
+    date?: string,
+    provisions: ConsentProvision[]
+};
+
+/**
+ * MVH submission / consent metadata (Modellvorhaben Genomsequenzierung).
+ *
+ * @see https://github.com/dnpm-dip/mtb-model — MVH_Metadata
+ */
+type MVHMetadata = {
+    type: MVHSubmissionType | string,
+    transferTAN: string,
+    modelProjectConsent: ModelProjectConsent,
+    researchConsents?: Record<string, any>[],
+    episodeOfCare?: Reference,
+    reasonResearchConsentMissing?: ResearchConsentMissingReason | string
+};
+
 export type PatientRecord = {
     patient: Patient,
+    metadata?: MVHMetadata,
     episodesOfCare: Episode[],
     diagnoses?: Diagnosis[],
+    familyMemberHistories?: FamilyMemberHistory[],
     guidelineTherapies: SystemicTherapy[],
     guidelineProcedures: OncoProcedure[],
     performanceStatus: PerformanceStatus[],
     specimens?: TumorSpecimen[],
     histologyReports?: HistologyReport[],
     ihcReports?: IHCReport[],
+    msiFindings?: MSI[],
     ngsReports?: SomaticNGSReport[],
+    priorDiagnosticReports?: MolecularDiagnosticReport[],
     carePlans?: CarePlan[],
     claims?: Claim[],
     claimResponses?: ClaimResponse[],
-    /**
-     * todo: new prop
-     */
     followUps?: FollowUp[],
     systemicTherapies?: History<SystemicTherapy>[],
-    responses?: Response[],
-    /**
-     * todo: new prop
-     */
-    priorDiagnosticReports?: MolecularDiagnosticReport[]
+    responses?: Response[]
 };

--- a/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId].vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId].vue
@@ -52,28 +52,38 @@ export default defineComponent({
 
         const navItems = computed<NavigationItem[]>(() => {
             const base = `/mtb/query/${props.entity.id}/patients/${entity.value?.patient.id}`;
-            return [
+            const items: NavigationItem[] = [
                 {
-                    name: 'Anamnese', 
-                    icon: 'fa6-solid:bars', 
-                    url: base, 
+                    name: 'Anamnese',
+                    icon: 'fa6-solid:bars',
+                    url: base,
                 },
                 {
-                    name: 'Diagnostik', 
-                    icon: 'fa6-solid:stethoscope', 
-                    url: `${base}/diagnostics`, 
+                    name: 'Diagnostik',
+                    icon: 'fa6-solid:stethoscope',
+                    url: `${base}/diagnostics`,
                 },
                 {
-                    name: 'Beschlüsse', 
-                    icon: 'fa6-solid:gavel', 
-                    url: `${base}/plans`, 
+                    name: 'Beschlüsse',
+                    icon: 'fa6-solid:gavel',
+                    url: `${base}/plans`,
                 },
                 {
-                    name: 'Follow-UP', 
-                    icon: 'fa6-solid:circle-arrow-up', 
-                    url: `${base}/follow-up`, 
+                    name: 'Follow-UP',
+                    icon: 'fa6-solid:circle-arrow-up',
+                    url: `${base}/follow-up`,
                 },
             ];
+
+            if (entity.value?.metadata) {
+                items.push({
+                    name: 'Metadaten',
+                    icon: 'fa6-solid:shield-halved',
+                    url: `${base}/metadata`,
+                });
+            }
+
+            return items;
         });
 
         return {

--- a/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/diagnostics.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/diagnostics.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { DExpandableContent } from '@dnpm-dip/core';
+import { DCommaList, DExpandableContent } from '@dnpm-dip/core';
 import { VCAlert } from '@vuecs/elements';
 import { VCIcon } from '@vuecs/icon';
 import type { PropType } from 'vue';
@@ -14,6 +14,7 @@ export default defineNuxtComponent({
     components: {
         MNGSReportRNAFusion,
         MngsReportDnaFusion,
+        DCommaList,
         DExpandableContent,
         MNGSReportCNV,
         MNgsReportSNV,
@@ -95,7 +96,7 @@ export default defineNuxtComponent({
                                 </div>
 
                                 <div><strong><VCIcon name="fa6-solid:code" /> Code</strong> {{ item.results.tumorMorphology.value.display }}</div>
-                                <div><strong><VCIcon name="fa6-solid:note-sticky" /> Notiz</strong> {{ item.results.tumorMorphology.notes }}</div>
+                                <div><strong><VCIcon name="fa6-solid:note-sticky" /> Notiz</strong> {{ item.results.tumorMorphology.note }}</div>
                             </div>
                             <div
                                 v-if="item.results.tumorCellContent"
@@ -153,12 +154,17 @@ export default defineNuxtComponent({
                                             <strong><VCIcon name="fa6-solid:code" /> Code</strong> {{ per.protein.display || per.protein.code }}
                                         </div>
                                         <div><strong><VCIcon name="fa6-solid:code" /> Wert</strong> {{ per.value.display || per.value.code }}</div>
-                                        <div><strong><VCIcon name="fa6-solid:code" /> TPS-Score</strong> {{ per.tpsScore }}</div>
+                                        <div v-if="typeof per.tpsScore === 'number'">
+                                            <strong><VCIcon name="fa6-solid:code" /> TPS-Score</strong> {{ per.tpsScore }}
+                                        </div>
+                                        <div v-if="typeof per.cpsScore === 'number'">
+                                            <strong><VCIcon name="fa6-solid:code" /> CPS-Score</strong> {{ per.cpsScore }}
+                                        </div>
                                         <div v-if="per.icScore">
-                                            <strong><VCIcon name="fa6-solid:code" /> TPS-Score</strong> {{ per.icScore.display || per.icScore.code }}
+                                            <strong><VCIcon name="fa6-solid:code" /> IC-Score</strong> {{ per.icScore.display || per.icScore.code }}
                                         </div>
                                         <div v-if="per.tcScore">
-                                            <strong><VCIcon name="fa6-solid:code" /> TPS-Score</strong> {{ per.tcScore.display || per.tcScore.code }}
+                                            <strong><VCIcon name="fa6-solid:code" /> TC-Score</strong> {{ per.tcScore.display || per.tcScore.code }}
                                         </div>
                                     </div>
                                 </template>
@@ -182,12 +188,17 @@ export default defineNuxtComponent({
                                             <strong><VCIcon name="fa6-solid:code" /> Code</strong> {{ per.protein.display || per.protein.code }}
                                         </div>
                                         <div><strong><VCIcon name="fa6-solid:code" /> Wert</strong> {{ per.value.display || per.value.code }}</div>
-                                        <div><strong><VCIcon name="fa6-solid:code" /> TPS-Score</strong> {{ per.tpsScore }}</div>
+                                        <div v-if="typeof per.tpsScore === 'number'">
+                                            <strong><VCIcon name="fa6-solid:code" /> TPS-Score</strong> {{ per.tpsScore }}
+                                        </div>
+                                        <div v-if="typeof per.cpsScore === 'number'">
+                                            <strong><VCIcon name="fa6-solid:code" /> CPS-Score</strong> {{ per.cpsScore }}
+                                        </div>
                                         <div v-if="per.icScore">
-                                            <strong><VCIcon name="fa6-solid:code" /> TPS-Score</strong> {{ per.icScore.display || per.icScore.code }}
+                                            <strong><VCIcon name="fa6-solid:code" /> IC-Score</strong> {{ per.icScore.display || per.icScore.code }}
                                         </div>
                                         <div v-if="per.tcScore">
-                                            <strong><VCIcon name="fa6-solid:code" /> TPS-Score</strong> {{ per.tcScore.display || per.tcScore.code }}
+                                            <strong><VCIcon name="fa6-solid:code" /> TC-Score</strong> {{ per.tcScore.display || per.tcScore.code }}
                                         </div>
                                     </div>
                                 </template>
@@ -200,6 +211,63 @@ export default defineNuxtComponent({
 
         <hr>
     </template>
+
+    <template v-if="record.msiFindings && record.msiFindings.length > 0">
+        <h5 class="section-label mb-2">
+            MSI-Befunde
+        </h5>
+        <div class="entity-card-group mb-3">
+            <template
+                v-for="item in record.msiFindings"
+                :key="item.id"
+            >
+                <div class="entity-card">
+                    <div>
+                        <strong><VCIcon name="fa6-solid:flask" /> Methode</strong>
+                        {{ item.method.display || item.method.code }}
+                    </div>
+                    <div>
+                        <strong><VCIcon name="fa6-solid:magnifying-glass-chart" /> Interpretation</strong>
+                        {{ item.interpretation.display || item.interpretation.code }}
+                    </div>
+                    <div><strong><VCIcon name="fa6-solid:hashtag" /> Wert</strong> {{ item.value }}</div>
+                </div>
+            </template>
+        </div>
+
+        <hr>
+    </template>
+
+    <template v-if="record.priorDiagnosticReports && record.priorDiagnosticReports.length > 0">
+        <h5 class="section-label mb-2">
+            Molekulare Vorbefunde
+        </h5>
+        <div class="entity-card-group mb-3">
+            <template
+                v-for="item in record.priorDiagnosticReports"
+                :key="item.id"
+            >
+                <div class="entity-card">
+                    <div>
+                        <strong><VCIcon name="fa6-solid:dna" /> Typ</strong>
+                        {{ item.type.display || item.type.code }}
+                    </div>
+                    <div><strong><VCIcon name="fa6-solid:clock" /> Datum</strong> {{ item.issuedOn }}</div>
+                    <div v-if="item.performer">
+                        <strong><VCIcon name="fa6-solid:user-doctor" /> Durchführender</strong>
+                        {{ item.performer.display || item.performer.id }}
+                    </div>
+                    <div v-if="item.results && item.results.length > 0">
+                        <strong><VCIcon name="fa6-solid:list" /> Ergebnisse</strong>
+                        <DCommaList :items="item.results" />
+                    </div>
+                </div>
+            </template>
+        </div>
+
+        <hr>
+    </template>
+
     <template v-if="record.ngsReports">
         <h5 class="section-label mb-2">
             NGS Berichte
@@ -221,6 +289,10 @@ export default defineNuxtComponent({
                                         <VCIcon name="fa6-solid:dna" /> Typ</strong>
                                     {{ item.type.display || item.type.code }}
                                 </div>
+                                <div v-if="item.specimen">
+                                    <strong><VCIcon name="fa6-solid:vial" /> Probe</strong>
+                                    {{ item.specimen.display || item.specimen.id }}
+                                </div>
                             </div>
                         </div>
                         <div class="flex-1 basis-0 px-2">
@@ -239,6 +311,28 @@ export default defineNuxtComponent({
                         </div>
                     </div>
                 </div>
+
+                <DExpandableContent v-if="item.metadata && item.metadata.length > 0">
+                    <template #header>
+                        <h6 class="section-label mb-2">
+                            Metadaten
+                        </h6>
+                    </template>
+                    <template #default>
+                        <template
+                            v-for="(meta, metaKey) in item.metadata"
+                            :key="metaKey"
+                        >
+                            <div class="entity-card mb-1">
+                                <div><strong><VCIcon name="fa6-solid:industry" /> Kit-Hersteller</strong> {{ meta.kitManufacturer }}</div>
+                                <div><strong><VCIcon name="fa6-solid:box" /> Kit-Typ</strong> {{ meta.kitType }}</div>
+                                <div><strong><VCIcon name="fa6-solid:microchip" /> Sequenzer</strong> {{ meta.sequencer }}</div>
+                                <div><strong><VCIcon name="fa6-solid:diagram-project" /> Pipeline</strong> {{ meta.pipeline }}</div>
+                                <div><strong><VCIcon name="fa6-solid:dna" /> Referenzgenom</strong> {{ meta.referenceGenome }}</div>
+                            </div>
+                        </template>
+                    </template>
+                </DExpandableContent>
 
                 <DExpandableContent>
                     <template #header>
@@ -320,6 +414,35 @@ export default defineNuxtComponent({
                         </DExpandableContent>
                     </div>
                 </div>
+
+                <DExpandableContent v-if="item.results.rnaSeqs && item.results.rnaSeqs.length > 0">
+                    <template #header>
+                        <h6 class="section-label mb-2">
+                            RNA-Seq
+                        </h6>
+                    </template>
+                    <template #default>
+                        <div class="entity-card-group">
+                            <template
+                                v-for="seq in item.results.rnaSeqs"
+                                :key="seq.id"
+                            >
+                                <div class="entity-card mb-1">
+                                    <div v-if="seq.gene">
+                                        <strong><VCIcon name="fa6-solid:dna" /> Gen</strong>
+                                        {{ seq.gene.display || seq.gene.code }}
+                                    </div>
+                                    <div><strong><VCIcon name="fa6-solid:chart-simple" /> TPM</strong> {{ seq.transcriptsPerMillion }}</div>
+                                    <div><strong><VCIcon name="fa6-solid:hashtag" /> Raw Counts</strong> {{ seq.rawCounts }}</div>
+                                    <div v-if="typeof seq.cohortRanking === 'number'">
+                                        <strong><VCIcon name="fa6-solid:ranking-star" /> Kohorten-Rang</strong>
+                                        {{ seq.cohortRanking }}
+                                    </div>
+                                </div>
+                            </template>
+                        </div>
+                    </template>
+                </DExpandableContent>
             </div>
         </template>
     </template>

--- a/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/follow-up.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/follow-up.vue
@@ -24,6 +24,34 @@ export default defineNuxtComponent({
 });
 </script>
 <template>
+    <template v-if="record.followUps && record.followUps.length > 0">
+        <div>
+            <h5 class="section-label mb-2">
+                Follow-Ups
+            </h5>
+        </div>
+        <div class="entity-card-group flex-row justify-evenly mb-3">
+            <template
+                v-for="(item, key) in record.followUps"
+                :key="key"
+            >
+                <div class="entity-card grow">
+                    <div><strong><VCIcon name="fa6-solid:clock" /> Datum</strong> {{ item.date }}</div>
+                    <div v-if="item.lastContactDate">
+                        <strong><VCIcon name="fa6-solid:calendar-check" /> Letzter Kontakt</strong>
+                        {{ item.lastContactDate }}
+                    </div>
+                    <div v-if="item.patientStatus">
+                        <strong><VCIcon name="fa6-solid:heart-pulse" /> Patientenstatus</strong>
+                        {{ item.patientStatus.display || item.patientStatus.code }}
+                    </div>
+                </div>
+            </template>
+        </div>
+
+        <hr>
+    </template>
+
     <template v-if="record.systemicTherapies">
         <div>
             <h5 class="section-label mb-2">
@@ -72,6 +100,22 @@ export default defineNuxtComponent({
                                 <strong><VCIcon name="fa6-solid:syringe" /> Dosierung</strong>
                                 {{ item.dosage.display || item.dosage.code }}
                             </div>
+                            <div v-if="item.therapyLine">
+                                <strong><VCIcon name="fa6-solid:stethoscope" /> Therapie Linie</strong>
+                                {{ item.therapyLine }}
+                            </div>
+                            <div v-if="item.intent">
+                                <strong><VCIcon name="fa6-solid:bullseye" /> Absicht</strong>
+                                {{ item.intent.display || item.intent.code }}
+                            </div>
+                            <div v-if="item.category">
+                                <strong><VCIcon name="fa6-solid:tags" /> Kategorie</strong>
+                                {{ item.category.display || item.category.code }}
+                            </div>
+                            <div v-if="item.recommendationFulfillmentStatus">
+                                <strong><VCIcon name="fa6-solid:list-check" /> Empfehlungs-Erfüllung</strong>
+                                {{ item.recommendationFulfillmentStatus.display || item.recommendationFulfillmentStatus.code }}
+                            </div>
                             <div v-if="item.notes">
                                 <div>
                                     <strong><VCIcon name="fa6-solid:note-sticky" /> Notiz</strong>
@@ -101,6 +145,10 @@ export default defineNuxtComponent({
                 <div class="entity-card grow mb-3">
                     <div><strong><VCIcon name="fa6-solid:clock" /> Datum</strong> {{ item.effectiveDate }}</div>
                     <div><strong><VCIcon name="fa6-solid:calculator" /> Code</strong> {{ item.value.display || item.value.code }}</div>
+                    <div v-if="item.method">
+                        <strong><VCIcon name="fa6-solid:flask" /> Methode</strong>
+                        {{ item.method.display || item.method.code }}
+                    </div>
                     <div v-if="item.therapy">
                         <strong><VCIcon name="fa6-solid:calculator" /> Indikation</strong>
                         {{ item.therapy.display || item.therapy.type }}

--- a/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/index.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { DCommaList, DPatient } from '@dnpm-dip/core';
+import { DCodingCommaList, DCommaList, DPatient } from '@dnpm-dip/core';
 import { VCIcon } from '@vuecs/icon';
 import type { PropType } from 'vue';
 import { defineNuxtComponent } from '#app';
@@ -7,9 +7,10 @@ import type { PatientRecord, QuerySession } from '../../../../../domains';
 
 export default defineNuxtComponent({
     components: {
-        DCommaList, 
-        DPatient, 
-        VCIcon, 
+        DCodingCommaList,
+        DCommaList,
+        DPatient,
+        VCIcon,
     },
     props: {
         entity: {
@@ -57,6 +58,74 @@ export default defineNuxtComponent({
             </template>
         </div>
 
+        <template v-if="record.diagnoses && record.diagnoses.length > 0">
+            <h5 class="section-label mb-2">
+                Diagnosen
+            </h5>
+            <div class="mb-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <template
+                    v-for="item in record.diagnoses"
+                    :key="item.id"
+                >
+                    <div class="entity-card">
+                        <div>
+                            <strong><VCIcon name="fa6-solid:code" /> Code</strong>
+                            {{ item.code.display || item.code.code }}
+                        </div>
+                        <div v-if="item.topography">
+                            <strong><VCIcon name="fa6-solid:compass" /> Topographie</strong>
+                            {{ item.topography.display || item.topography.code }}
+                        </div>
+                        <template v-if="item.type && item.type.history.length > 0">
+                            <div>
+                                <strong><VCIcon name="fa6-solid:tag" /> Typ</strong>
+                                {{ item.type.history[0].value.display || item.type.history[0].value.code }}
+                                <span class="text-fg-muted">({{ item.type.history[0].date }})</span>
+                            </div>
+                        </template>
+                        <div><strong><VCIcon name="fa6-solid:clock" /> Erfassungsdatum</strong> {{ item.recordedOn }}</div>
+                        <div v-if="item.guidelineTreatmentStatus">
+                            <strong><VCIcon name="fa6-solid:circle-info" /> Leitlinien-Behandlungsstatus</strong>
+                            {{ item.guidelineTreatmentStatus.display || item.guidelineTreatmentStatus.code }}
+                        </div>
+                        <template v-if="item.staging && item.staging.history.length > 0">
+                            <div>
+                                <strong><VCIcon name="fa6-solid:layer-group" /> Staging</strong>
+                                {{ item.staging.history[0].method.display || item.staging.history[0].method.code }}
+                                <span class="text-fg-muted">({{ item.staging.history[0].date }})</span>
+                            </div>
+                            <div v-if="item.staging.history[0].tnmClassification">
+                                <strong><VCIcon name="fa6-solid:ruler" /> TNM</strong>
+                                <DCodingCommaList
+                                    :items="[
+                                        item.staging.history[0].tnmClassification.tumor,
+                                        item.staging.history[0].tnmClassification.nodes,
+                                        item.staging.history[0].tnmClassification.metastasis,
+                                    ]"
+                                />
+                            </div>
+                            <div v-if="item.staging.history[0].otherClassifications">
+                                <strong><VCIcon name="fa6-solid:list" /> Weitere Klassifikationen</strong>
+                                <DCodingCommaList :items="item.staging.history[0].otherClassifications" />
+                            </div>
+                        </template>
+                        <div v-if="item.grading && item.grading.history.length > 0">
+                            <strong><VCIcon name="fa6-solid:signal" /> Grading</strong>
+                            <DCodingCommaList :items="item.grading.history[0].codes" />
+                        </div>
+                        <div v-if="item.germlineCodes && item.germlineCodes.length > 0">
+                            <strong><VCIcon name="fa6-solid:dna" /> Keimbahn-Codes</strong>
+                            <DCodingCommaList :items="item.germlineCodes" />
+                        </div>
+                        <div v-if="item.notes && item.notes.length > 0">
+                            <strong><VCIcon name="fa6-solid:note-sticky" /> Notiz</strong>
+                            <DCommaList :items="item.notes" />
+                        </div>
+                    </div>
+                </template>
+            </div>
+        </template>
+
         <h5 class="section-label mb-2">
             Leitlinien-Therapien
         </h5>
@@ -93,9 +162,25 @@ export default defineNuxtComponent({
                                 <strong><VCIcon name="fa6-solid:circle-info" /> Status Grund</strong>
                                 {{ item.statusReason.display || item.statusReason.code }}
                             </div>
+                            <div v-if="item.recordedOn">
+                                <strong><VCIcon name="fa6-solid:clock" /> Erfassungsdatum</strong>
+                                {{ item.recordedOn }}
+                            </div>
                             <div v-if="item.therapyLine">
                                 <strong><VCIcon name="fa6-solid:stethoscope" /> Therapie Linie</strong>
                                 {{ item.therapyLine }}
+                            </div>
+                            <div v-if="item.intent">
+                                <strong><VCIcon name="fa6-solid:bullseye" /> Absicht</strong>
+                                {{ item.intent.display || item.intent.code }}
+                            </div>
+                            <div v-if="item.category">
+                                <strong><VCIcon name="fa6-solid:tags" /> Kategorie</strong>
+                                {{ item.category.display || item.category.code }}
+                            </div>
+                            <div v-if="item.recommendationFulfillmentStatus">
+                                <strong><VCIcon name="fa6-solid:list-check" /> Empfehlungs-Erfüllung</strong>
+                                {{ item.recommendationFulfillmentStatus.display || item.recommendationFulfillmentStatus.code }}
                             </div>
                             <div v-if="item.dosage">
                                 <strong><VCIcon name="fa6-solid:syringe" /> Dosierung</strong>
@@ -110,8 +195,6 @@ export default defineNuxtComponent({
                 </div>
             </template>
         </div>
-
-        <!-- todo: add diagnosis -->
 
         <h5 class="section-label mb-2">
             Leitlinien-Prozeduren
@@ -183,5 +266,24 @@ export default defineNuxtComponent({
                 </div>
             </template>
         </div>
+
+        <template v-if="record.familyMemberHistories && record.familyMemberHistories.length > 0">
+            <h5 class="section-label mb-2">
+                Familienanamnese
+            </h5>
+            <div class="mb-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <template
+                    v-for="item in record.familyMemberHistories"
+                    :key="item.id"
+                >
+                    <div class="entity-card">
+                        <div>
+                            <strong><VCIcon name="fa6-solid:people-roof" /> Verwandtschaftsverhältnis</strong>
+                            {{ item.relationship.display || item.relationship.code }}
+                        </div>
+                    </div>
+                </template>
+            </div>
+        </template>
     </div>
 </template>

--- a/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/index.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/index.vue
@@ -76,11 +76,14 @@ export default defineNuxtComponent({
                             <strong><VCIcon name="fa6-solid:compass" /> Topographie</strong>
                             {{ item.topography.display || item.topography.code }}
                         </div>
-                        <template v-if="item.type && item.type.history.length > 0">
+                        <template
+                            v-for="type in (item.type ? item.type.history.slice(0, 1) : [])"
+                            :key="type.date"
+                        >
                             <div>
                                 <strong><VCIcon name="fa6-solid:tag" /> Typ</strong>
-                                {{ item.type.history[0].value.display || item.type.history[0].value.code }}
-                                <span class="text-fg-muted">({{ item.type.history[0].date }})</span>
+                                {{ type.value.display || type.value.code }}
+                                <span class="text-fg-muted">({{ type.date }})</span>
                             </div>
                         </template>
                         <div><strong><VCIcon name="fa6-solid:clock" /> Erfassungsdatum</strong> {{ item.recordedOn }}</div>
@@ -88,31 +91,39 @@ export default defineNuxtComponent({
                             <strong><VCIcon name="fa6-solid:circle-info" /> Leitlinien-Behandlungsstatus</strong>
                             {{ item.guidelineTreatmentStatus.display || item.guidelineTreatmentStatus.code }}
                         </div>
-                        <template v-if="item.staging && item.staging.history.length > 0">
+                        <template
+                            v-for="staging in (item.staging ? item.staging.history.slice(0, 1) : [])"
+                            :key="staging.date"
+                        >
                             <div>
                                 <strong><VCIcon name="fa6-solid:layer-group" /> Staging</strong>
-                                {{ item.staging.history[0].method.display || item.staging.history[0].method.code }}
-                                <span class="text-fg-muted">({{ item.staging.history[0].date }})</span>
+                                {{ staging.method.display || staging.method.code }}
+                                <span class="text-fg-muted">({{ staging.date }})</span>
                             </div>
-                            <div v-if="item.staging.history[0].tnmClassification">
+                            <div v-if="staging.tnmClassification">
                                 <strong><VCIcon name="fa6-solid:ruler" /> TNM</strong>
                                 <DCodingCommaList
                                     :items="[
-                                        item.staging.history[0].tnmClassification.tumor,
-                                        item.staging.history[0].tnmClassification.nodes,
-                                        item.staging.history[0].tnmClassification.metastasis,
+                                        staging.tnmClassification.tumor,
+                                        staging.tnmClassification.nodes,
+                                        staging.tnmClassification.metastasis,
                                     ]"
                                 />
                             </div>
-                            <div v-if="item.staging.history[0].otherClassifications">
+                            <div v-if="staging.otherClassifications">
                                 <strong><VCIcon name="fa6-solid:list" /> Weitere Klassifikationen</strong>
-                                <DCodingCommaList :items="item.staging.history[0].otherClassifications" />
+                                <DCodingCommaList :items="staging.otherClassifications" />
                             </div>
                         </template>
-                        <div v-if="item.grading && item.grading.history.length > 0">
-                            <strong><VCIcon name="fa6-solid:signal" /> Grading</strong>
-                            <DCodingCommaList :items="item.grading.history[0].codes" />
-                        </div>
+                        <template
+                            v-for="grading in (item.grading ? item.grading.history.slice(0, 1) : [])"
+                            :key="grading.date"
+                        >
+                            <div>
+                                <strong><VCIcon name="fa6-solid:signal" /> Grading</strong>
+                                <DCodingCommaList :items="grading.codes" />
+                            </div>
+                        </template>
                         <div v-if="item.germlineCodes && item.germlineCodes.length > 0">
                             <strong><VCIcon name="fa6-solid:dna" /> Keimbahn-Codes</strong>
                             <DCodingCommaList :items="item.germlineCodes" />

--- a/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/metadata.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/metadata.vue
@@ -1,0 +1,182 @@
+<script lang="ts">
+import { DFact } from '@dnpm-dip/core';
+import { VCAlert } from '@vuecs/elements';
+import { VCIcon } from '@vuecs/icon';
+import type { PropType } from 'vue';
+import { defineNuxtComponent } from '#app';
+import type { PatientRecord, QuerySession } from '../../../../../domains';
+
+const SUBMISSION_TYPE_LABELS: Record<string, string> = {
+    initial: 'Erstmeldung',
+    correction: 'Korrektur',
+    test: 'Test',
+    addition: 'Ergänzung',
+    followup: 'Follow-Up',
+};
+
+const PURPOSE_LABELS: Record<string, string> = {
+    'case-identification': 'Fallidentifikation',
+    reidentification: 'Reidentifikation',
+    sequencing: 'Sequenzierung',
+};
+
+const PROVISION_TYPE_LABELS: Record<string, string> = {
+    permit: 'Erlaubt',
+    deny: 'Abgelehnt',
+};
+
+const CONSENT_MISSING_LABELS: Record<string, string> = {
+    'organizational-issues': 'Organisatorische Gründe',
+    'technical-issues': 'Technische Gründe',
+    'patient-inability': 'Patient nicht einwilligungsfähig',
+    'other-patient-reason': 'Anderer patientenbezogener Grund',
+    'consent-not-returned': 'Einwilligung nicht zurückerhalten',
+    'patient-refusal': 'Ablehnung durch Patient',
+};
+
+export default defineNuxtComponent({
+    components: {
+        DFact,
+        VCAlert,
+        VCIcon,
+    },
+    props: {
+        entity: {
+            type: Object as PropType<QuerySession>,
+            required: true,
+        },
+        record: {
+            type: Object as PropType<PatientRecord>,
+            required: true,
+        },
+    },
+    methods: {
+        submissionTypeLabel(value: string) {
+            return SUBMISSION_TYPE_LABELS[value] || value;
+        },
+        purposeLabel(value: string) {
+            return PURPOSE_LABELS[value] || value;
+        },
+        provisionTypeLabel(value: string) {
+            return PROVISION_TYPE_LABELS[value] || value;
+        },
+        consentMissingLabel(value: string) {
+            return CONSENT_MISSING_LABELS[value] || value;
+        },
+    },
+});
+</script>
+<template>
+    <template v-if="record.metadata">
+        <h5 class="section-label mb-2">
+            Meldung
+        </h5>
+        <div class="entity-card mb-4">
+            <div class="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3">
+                <DFact
+                    label="Meldungstyp"
+                    icon="fa6-solid:file-arrow-up"
+                >
+                    {{ submissionTypeLabel(record.metadata.type) }}
+                </DFact>
+                <DFact
+                    label="Transfer-TAN"
+                    icon="fa6-solid:hashtag"
+                >
+                    <span class="font-mono text-xs">{{ record.metadata.transferTAN }}</span>
+                </DFact>
+                <DFact
+                    v-if="record.metadata.episodeOfCare"
+                    label="Fall"
+                    icon="fa6-solid:folder-open"
+                >
+                    {{ record.metadata.episodeOfCare.display || record.metadata.episodeOfCare.id }}
+                </DFact>
+            </div>
+        </div>
+
+        <template v-if="record.metadata.modelProjectConsent">
+            <h5 class="section-label mb-2">
+                Modellvorhaben-Einwilligung
+            </h5>
+            <div class="entity-card mb-4">
+                <div class="mb-3 flex flex-wrap items-center gap-x-8 gap-y-2">
+                    <DFact
+                        label="Version"
+                        icon="fa6-solid:code-branch"
+                    >
+                        {{ record.metadata.modelProjectConsent.version }}
+                    </DFact>
+                    <DFact
+                        v-if="record.metadata.modelProjectConsent.date"
+                        label="Datum"
+                        icon="fa6-solid:calendar-day"
+                    >
+                        {{ record.metadata.modelProjectConsent.date }}
+                    </DFact>
+                </div>
+
+                <h6 class="section-label mb-2">
+                    Regelungen
+                </h6>
+                <div class="flex flex-col gap-2">
+                    <template
+                        v-for="(provision, provisionKey) in record.metadata.modelProjectConsent.provisions"
+                        :key="provisionKey"
+                    >
+                        <div class="flex items-center justify-between gap-3 rounded-lg border border-border bg-bg px-3 py-2">
+                            <div class="min-w-0">
+                                <div class="text-sm font-medium">
+                                    {{ purposeLabel(provision.purpose) }}
+                                </div>
+                                <div class="text-xs text-fg-muted">
+                                    {{ provision.date }}
+                                </div>
+                            </div>
+                            <span
+                                class="shrink-0 rounded-full px-2 py-0.5 text-xs font-medium"
+                                :class="provision.type === 'permit'
+                                    ? 'bg-success-500/10 text-success-600'
+                                    : 'bg-error-500/10 text-error-600'"
+                            >
+                                <VCIcon :name="provision.type === 'permit' ? 'fa6-solid:check' : 'fa6-solid:xmark'" />
+                                {{ provisionTypeLabel(provision.type) }}
+                            </span>
+                        </div>
+                    </template>
+                </div>
+            </div>
+        </template>
+
+        <template
+            v-if="(record.metadata.researchConsents && record.metadata.researchConsents.length > 0)
+                || record.metadata.reasonResearchConsentMissing"
+        >
+            <h5 class="section-label mb-2">
+                Forschungs-Einwilligungen
+            </h5>
+            <div class="entity-card mb-4">
+                <div v-if="record.metadata.researchConsents && record.metadata.researchConsents.length > 0">
+                    <VCIcon name="fa6-solid:file-signature" />
+                    {{ record.metadata.researchConsents.length }} Einwilligung(en) hinterlegt
+                </div>
+                <div
+                    v-if="record.metadata.reasonResearchConsentMissing"
+                    class="text-error-600"
+                >
+                    <strong><VCIcon name="fa6-solid:triangle-exclamation" /> Grund für fehlende Einwilligung</strong>
+                    {{ consentMissingLabel(record.metadata.reasonResearchConsentMissing) }}
+                </div>
+            </div>
+        </template>
+    </template>
+    <template v-else>
+        <VCAlert
+            color="info"
+            variant="soft"
+            size="sm"
+        >
+            Es sind keine Metadaten vorhanden.
+        </VCAlert>
+    </template>
+</template>

--- a/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/metadata.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/metadata.vue
@@ -135,11 +135,19 @@ export default defineNuxtComponent({
                             </div>
                             <span
                                 class="shrink-0 rounded-full px-2 py-0.5 text-xs font-medium"
-                                :class="provision.type === 'permit'
-                                    ? 'bg-success-500/10 text-success-600'
-                                    : 'bg-error-500/10 text-error-600'"
+                                :class="{
+                                    'bg-success-500/10 text-success-600': provision.type === 'permit',
+                                    'bg-error-500/10 text-error-600': provision.type === 'deny',
+                                    'bg-neutral-500/10 text-fg-muted': provision.type !== 'permit' && provision.type !== 'deny',
+                                }"
                             >
-                                <VCIcon :name="provision.type === 'permit' ? 'fa6-solid:check' : 'fa6-solid:xmark'" />
+                                <VCIcon
+                                    :name="provision.type === 'permit'
+                                        ? 'fa6-solid:check'
+                                        : provision.type === 'deny'
+                                            ? 'fa6-solid:xmark'
+                                            : 'fa6-solid:question'"
+                                />
                                 {{ provisionTypeLabel(provision.type) }}
                             </span>
                         </div>

--- a/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/plans.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/plans.vue
@@ -29,7 +29,7 @@ export default defineNuxtComponent({
                 <div class="entity-card grow mb-3">
                     <div class="flex flex-wrap -mx-2 mb-3">
                         <div class="flex-1 basis-0 px-2">
-                            <div>
+                            <div v-if="item.reason">
                                 <strong><VCIcon name="fa6-solid:calculator" /> Grund</strong>
                                 {{ item.reason.display || item.reason.type }}
                             </div>
@@ -198,6 +198,10 @@ export default defineNuxtComponent({
                                             <hr>
                                         </template>
                                         <div><strong><VCIcon name="fa6-solid:clock" /> Datum</strong> {{ recommendation.issuedOn }}</div>
+                                        <div v-if="recommendation.reason">
+                                            <strong><VCIcon name="fa6-solid:calculator" /> Grund</strong>
+                                            {{ recommendation.reason.display || recommendation.reason.id }}
+                                        </div>
                                         <div v-if="recommendation.code">
                                             <strong><VCIcon name="fa6-solid:code" /> Code</strong>
                                             {{ recommendation.code.display || recommendation.code.code }}

--- a/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/plans.vue
+++ b/packages/mtb/src/runtime/pages/query/[id]/patients/[patientId]/plans.vue
@@ -76,6 +76,10 @@ export default defineNuxtComponent({
                                             <hr>
                                         </template>
                                         <div><strong><VCIcon name="fa6-solid:clock" /> Datum</strong> {{ recommendation.issuedOn }}</div>
+                                        <div v-if="recommendation.reason">
+                                            <strong><VCIcon name="fa6-solid:calculator" /> Grund</strong>
+                                            {{ recommendation.reason.display || recommendation.reason.id }}
+                                        </div>
                                         <div v-if="recommendation.medication">
                                             <strong><VCIcon name="fa6-solid:pills" /> Medikation</strong>
                                             <DCodingCommaList :items="recommendation.medication" />
@@ -91,10 +95,10 @@ export default defineNuxtComponent({
                                         <div v-if="recommendation.supportingVariants">
                                             <strong><VCIcon name="fa6-solid:circle-check" /> Stützende molekulare Alterationen</strong><br>
                                             <template
-                                                v-for="el in recommendation.supportingVariants"
-                                                :key="el.id"
+                                                v-for="(el, elKey) in recommendation.supportingVariants"
+                                                :key="elKey"
                                             >
-                                                <p>&bull; {{ el.display }}</p>
+                                                <p>&bull; {{ el.display || el.gene?.display || el.variant?.id }}</p>
                                             </template>
                                         </div>
                                         <div v-if="recommendation.priority">
@@ -147,25 +151,163 @@ export default defineNuxtComponent({
                                 >
                                     <div class="mb-2">
                                         <div><strong><VCIcon name="fa6-solid:clock" /> Datum</strong> {{ recommendation.issuedOn }}</div>
+                                        <div v-if="recommendation.priority">
+                                            <strong><VCIcon name="fa6-solid:clock" /> Priorität</strong>
+                                            {{ recommendation.priority.display || recommendation.priority.code }}
+                                        </div>
+                                        <div v-if="recommendation.study && recommendation.study.length > 0">
+                                            <strong><VCIcon name="fa6-solid:flask-vial" /> Studien</strong><br>
+                                            <template
+                                                v-for="study in recommendation.study"
+                                                :key="study.id"
+                                            >
+                                                <p>&bull; {{ study.display || study.id }} <span class="text-fg-muted">({{ study.system }})</span></p>
+                                            </template>
+                                        </div>
                                         <div v-if="recommendation.supportingVariants">
                                             <strong><VCIcon name="fa6-solid:circle-check" /> Stützende Evidenz</strong><br>
                                             <template
-                                                v-for="el in recommendation.supportingVariants"
-                                                :key="el.id"
+                                                v-for="(el, elKey) in recommendation.supportingVariants"
+                                                :key="elKey"
                                             >
-                                                <p>&bull; {{ el.display }}</p>
+                                                <p>&bull; {{ el.display || el.gene?.display || el.variant?.id }}</p>
                                             </template>
                                         </div>
-                                        <div v-if="recommendation.levelOfEvidence">
+                                        <div v-if="recommendation.levelOfEvidence && recommendation.levelOfEvidence.grading">
                                             <strong><VCIcon name="fa6-solid:chart-line" /> Evidenz-Grad</strong>
-                                            {{ recommendation.levelOfEvidence.display || recommendation.levelOfEvidence.code }}
+                                            {{ recommendation.levelOfEvidence.grading.display || recommendation.levelOfEvidence.grading.code }}
                                         </div>
-
-                                    <!-- todo: studien anzeigen -->
                                     </div>
                                 </template>
                             </div>
                         </div>
+                        <div
+                            v-if="item.procedureRecommendations"
+                            class="flex-1 basis-0 px-2"
+                        >
+                            <div class="entity-card">
+                                <div class="text-center mb-3">
+                                    <strong>Prozedur-Empfehlungen</strong>
+                                </div>
+                                <template
+                                    v-for="(recommendation, recommendationKey) in item.procedureRecommendations"
+                                    :key="recommendation.id"
+                                >
+                                    <div class="mb-2">
+                                        <template v-if="recommendationKey > 0">
+                                            <hr>
+                                        </template>
+                                        <div><strong><VCIcon name="fa6-solid:clock" /> Datum</strong> {{ recommendation.issuedOn }}</div>
+                                        <div v-if="recommendation.code">
+                                            <strong><VCIcon name="fa6-solid:code" /> Code</strong>
+                                            {{ recommendation.code.display || recommendation.code.code }}
+                                        </div>
+                                        <div v-if="recommendation.priority">
+                                            <strong><VCIcon name="fa6-solid:clock" /> Priorität</strong>
+                                            {{ recommendation.priority.display || recommendation.priority.code }}
+                                        </div>
+                                        <div v-if="recommendation.supportingVariants">
+                                            <strong><VCIcon name="fa6-solid:circle-check" /> Stützende molekulare Alterationen</strong><br>
+                                            <template
+                                                v-for="(el, elKey) in recommendation.supportingVariants"
+                                                :key="elKey"
+                                            >
+                                                <p>&bull; {{ el.display || el.gene?.display || el.variant?.id }}</p>
+                                            </template>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </div>
+                    <div
+                        v-if="item.rebiopsyRequests || item.histologyReevaluationRequests"
+                        class="flex flex-wrap -mx-2 mt-2"
+                    >
+                        <div
+                            v-if="item.rebiopsyRequests"
+                            class="flex-1 basis-0 px-2"
+                        >
+                            <div class="entity-card">
+                                <div class="text-center mb-3">
+                                    <strong>Rebiopsie-Anforderungen</strong>
+                                </div>
+                                <template
+                                    v-for="request in item.rebiopsyRequests"
+                                    :key="request.id"
+                                >
+                                    <div>
+                                        <strong><VCIcon name="fa6-solid:clock" /> Datum</strong> {{ request.issuedOn }}
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                        <div
+                            v-if="item.histologyReevaluationRequests"
+                            class="flex-1 basis-0 px-2"
+                        >
+                            <div class="entity-card">
+                                <div class="text-center mb-3">
+                                    <strong>Histologie-Reevaluierungen</strong>
+                                </div>
+                                <template
+                                    v-for="request in item.histologyReevaluationRequests"
+                                    :key="request.id"
+                                >
+                                    <div>
+                                        <strong><VCIcon name="fa6-solid:clock" /> Datum</strong> {{ request.issuedOn }}
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+        </div>
+    </template>
+
+    <template v-if="record.claims && record.claims.length > 0">
+        <h5 class="section-label mb-2">
+            Kostenübernahme-Anträge
+        </h5>
+        <div class="mb-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            <template
+                v-for="item in record.claims"
+                :key="item.id"
+            >
+                <div class="entity-card">
+                    <div><strong><VCIcon name="fa6-solid:clock" /> Datum</strong> {{ item.issuedOn }}</div>
+                    <div v-if="item.stage">
+                        <strong><VCIcon name="fa6-solid:layer-group" /> Stufe</strong>
+                        {{ item.stage.display || item.stage.code }}
+                    </div>
+                    <div v-if="item.requestedMedication && item.requestedMedication.length > 0">
+                        <strong><VCIcon name="fa6-solid:pills" /> Beantragte Medikation</strong>
+                        <DCodingCommaList :items="item.requestedMedication" />
+                    </div>
+                </div>
+            </template>
+        </div>
+    </template>
+
+    <template v-if="record.claimResponses && record.claimResponses.length > 0">
+        <h5 class="section-label mb-2">
+            Antworten auf Kostenübernahme-Anträge
+        </h5>
+        <div class="mb-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            <template
+                v-for="item in record.claimResponses"
+                :key="item.id"
+            >
+                <div class="entity-card">
+                    <div><strong><VCIcon name="fa6-solid:clock" /> Datum</strong> {{ item.issuedOn }}</div>
+                    <div v-if="item.status">
+                        <strong><VCIcon name="fa6-solid:circle-check" /> Status</strong>
+                        {{ item.status.display || item.status.code }}
+                    </div>
+                    <div v-if="item.statusReason && item.statusReason.length > 0">
+                        <strong><VCIcon name="fa6-solid:circle-info" /> Status Grund</strong>
+                        <DCodingCommaList :items="item.statusReason" />
                     </div>
                 </div>
             </template>


### PR DESCRIPTION
## Summary

Completes the MTB patient-record DTO against the ETL patient-record schema
(`/api/mtb/etl/patient-record/schema`) and renders **every** top-level
section of the record across the patient tabs. Previously several
collections and many fields were missing from both the DTO and the views.

## DTO (`packages/mtb` + `packages/core`)

- New: `familyMemberHistories`, `msiFindings`, and MVH submission `metadata`
  (`ModelProjectConsent` + provisions, research consents, transfer TAN).
- Corrections to match the schema: tumor staging `tnmClassification`
  (was `tmnClassification`), single-`Coding` diagnosis `type`, histology
  `tumorMorphology.note`, `Response.method`, `CarePlan.boardType`.
- Recommendation `supportingVariants` now reuse core `GeneAlterationReference`;
  added study/publication references, `ProteinExpression.cpsScore`, and typed
  NGS `rnaSeqs` / `metadata` / `specimen`.
- Core `Patient` gains the optional `age` quantity.

## Views

- **Anamnese** — new *Diagnosen* and *Familienanamnese* sections; guideline
  therapies now show intent / category / fulfilment / recorded date.
- **Diagnostik** — new *MSI-Befunde*, *Molekulare Vorbefunde*, NGS metadata /
  specimen / RNA-seq; fixed IHC scores that were all mislabeled *TPS-Score*.
- **Beschlüsse** — procedure recommendations, rebiopsy & histology
  re-evaluation requests, study-enrolment references, plus *Kostenübernahme-
  Anträge* / *Antworten* (claims & claim responses).
- **Follow-UP** — new *Follow-Ups* section and response method.
- **Metadaten** — new tab (shown only when `metadata` is present) rendering
  consent provisions as green *Erlaubt* / red *Abgelehnt* status pills, with
  machine tokens mapped to German labels.

`DPatient` now also surfaces age and health-insurance type.

## Verification

- `@dnpm-dip/core` and `@dnpm-dip/mtb` build cleanly; ESLint passes on all
  changed files; the portal dev server boots with the changes.
- The only build errors are two pre-existing `TS2883` `VCNavItems` type-
  portability errors on untouched files (confirmed present on `master`).

## Open questions for review

- `metadata` lives in the ETL **submission** schema — whether the read model
  (`getPatientRecord`) actually returns it still needs confirmation against a
  live record. The Metadaten tab appears only when it does.
- Diagnosis `type` / `staging` / `grading` show `history[0]` as the current
  entry, matching the existing `systemicTherapies` convention; worth a sanity
  check against real data for ordering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patient profiles now show age, health insurance, diagnoses, family history, prior diagnostic reports, and follow-up information when available.
  * Added patient metadata and consent details, including research-consent status.
  * Diagnostic views now include RNA sequencing, MSI findings, specimen details, and expandable report metadata.
  * Therapy and care-plan views display additional treatment, recommendation, study, and response details.

* **Bug Fixes**
  * Corrected histology, IHC, and MSI score labels and improved conditional score display.
  * Improved handling and presentation of diagnostic notes and supporting evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->