### PR TITLE
feat: migrate UI to rapiq v2 and @authup beta.54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,14 +48,16 @@
             }
         },
         "node_modules/@authup/access": {
-            "version": "1.0.0-beta.52",
-            "resolved": "https://registry.npmjs.org/@authup/access/-/access-1.0.0-beta.52.tgz",
-            "integrity": "sha512-MCaQiQcm+yp/AQE9j6+M+axdaJ9+K8mj63F9sCgYNCySqrAahMlNM2Xlehhi2jAcKBbmIailIomK4LRw3xF7OQ==",
+            "version": "1.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@authup/access/-/access-1.0.0-beta.54.tgz",
+            "integrity": "sha512-inEgMvzSqomWFaumzr817CtUhAipoNSPez/TODIHF+PXG+fn5Ey03km8KMGxasbQ0Eh60DzgA+B5xcTdShKbKg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/errors": "^1.0.0-beta.52",
-                "@authup/kit": "^1.0.0-beta.52",
-                "@ucast/mongo2js": "^2.0.0",
+                "@authup/errors": "^1.0.0-beta.54",
+                "@authup/kit": "^1.0.0-beta.54",
+                "@rapiq/core": "^2.0.0-beta.7",
+                "@rapiq/memory": "^2.0.0-beta.7",
+                "@rapiq/parser-mongo": "^2.0.0-beta.7",
                 "@validup/zod": "^0.3.3",
                 "smob": "^1.6.1",
                 "validup": "^0.5.1",
@@ -66,23 +68,24 @@
             }
         },
         "node_modules/@authup/client-web-kit": {
-            "version": "1.0.0-beta.52",
-            "resolved": "https://registry.npmjs.org/@authup/client-web-kit/-/client-web-kit-1.0.0-beta.52.tgz",
-            "integrity": "sha512-VBHMfLz5EtN/ogro1oQrVWDrsNKdT4w1+769SNca/CxeppQ03pCBrYjYR3qFjCEcX7AU5SqTYgtRdJCQR7yAcA==",
+            "version": "1.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@authup/client-web-kit/-/client-web-kit-1.0.0-beta.54.tgz",
+            "integrity": "sha512-jOhHWkkEr09LZsmnrdEQ6ffkcZ9aRKPB9Ik19C7REBOJcdZpjjlnZB1+k1ymC+gh4Vn/MRf2J9fnAdeUyZgQbg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/access": "^1.0.0-beta.52",
-                "@authup/core-http-kit": "^1.0.0-beta.52",
-                "@authup/core-kit": "^1.0.0-beta.52",
-                "@authup/core-realtime-kit": "^1.0.0-beta.52",
-                "@authup/i18n": "^1.0.0-beta.52",
-                "@authup/kit": "^1.0.0-beta.52",
-                "@authup/specs": "^1.0.0-beta.52",
+                "@authup/access": "^1.0.0-beta.54",
+                "@authup/core-http-kit": "^1.0.0-beta.54",
+                "@authup/core-kit": "^1.0.0-beta.54",
+                "@authup/core-realtime-kit": "^1.0.0-beta.54",
+                "@authup/i18n": "^1.0.0-beta.54",
+                "@authup/kit": "^1.0.0-beta.54",
+                "@authup/specs": "^1.0.0-beta.54",
                 "@ilingo/validup": "^1.0.1",
                 "@posva/event-emitter": "^1.0.3",
+                "@rapiq/core": "^2.0.0-beta.7",
+                "@simplewebauthn/browser": "^13.3.0",
                 "@validup/zod": "^0.3.3",
                 "@vueuse/integrations": "^14.3.0",
-                "rapiq": "^0.9.0",
                 "smob": "^1.6.1",
                 "universal-cookie": "^8.1.2"
             },
@@ -96,7 +99,7 @@
                 "@vuecs/button": "^1.3.0",
                 "@vuecs/core": "^3.4.0",
                 "@vuecs/elements": "^1.4.0",
-                "@vuecs/forms": "^5.3.2",
+                "@vuecs/forms": "^5.3.3",
                 "@vuecs/icon": "^1.0.3",
                 "@vuecs/link": "^2.0.3",
                 "@vuecs/list": "^1.1.1",
@@ -116,18 +119,18 @@
             }
         },
         "node_modules/@authup/client-web-kit-theme": {
-            "version": "1.0.0-beta.52",
-            "resolved": "https://registry.npmjs.org/@authup/client-web-kit-theme/-/client-web-kit-theme-1.0.0-beta.52.tgz",
-            "integrity": "sha512-HpT+lWbo9S54aXKzAWbEh2pmq3aCsxcKc8ZmE7iAFobA7X5QteFk5SYPsuR6QV9xso0UWMPTd+LWEDY56lMYjg==",
+            "version": "1.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@authup/client-web-kit-theme/-/client-web-kit-theme-1.0.0-beta.54.tgz",
+            "integrity": "sha512-PTbxfhEWIvV1cJfatl2MSTz9XScWMcL1KYVVBcuU4iQCi2oD/0IopK/QttSr2fqR3KgePWc1/t7Ix08tSWNHug==",
             "license": "Apache-2.0",
             "engines": {
                 "node": "^22.13.0 || ^23.5.0 || >=24.0.0"
             },
             "peerDependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.52",
+                "@authup/client-web-kit": "^1.0.0-beta.54",
                 "@vuecs/core": "^3.4.0",
                 "@vuecs/design": "^1.0.8",
-                "@vuecs/theme-tailwind": "^6.3.0",
+                "@vuecs/theme-tailwind": "^6.3.1",
                 "tailwindcss": "^4.3.2"
             },
             "peerDependenciesMeta": {
@@ -137,15 +140,15 @@
             }
         },
         "node_modules/@authup/client-web-nuxt": {
-            "version": "1.0.0-beta.52",
-            "resolved": "https://registry.npmjs.org/@authup/client-web-nuxt/-/client-web-nuxt-1.0.0-beta.52.tgz",
-            "integrity": "sha512-82FZdY0H76c1ZCCW4xddgsjKbrPKumZrH1s9MmY9TYKLl7jT80XvTwx27Vghm14ZgYk/EsNVMTq5jbTT6vSsAQ==",
+            "version": "1.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@authup/client-web-nuxt/-/client-web-nuxt-1.0.0-beta.54.tgz",
+            "integrity": "sha512-HFgdQVUDpoLMpbj4Nqtv+pTtntyDUavYXuBIwsLfLnugyQ7mnHoJUB35CLKgn5DuF+sBDcIim0SYp37lDvh4mg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/access": "^1.0.0-beta.52",
-                "@authup/client-web-kit": "^1.0.0-beta.52",
-                "@authup/kit": "^1.0.0-beta.52",
+                "@authup/access": "^1.0.0-beta.54",
+                "@authup/client-web-kit": "^1.0.0-beta.54",
+                "@authup/kit": "^1.0.0-beta.54",
                 "@nuxt/kit": "^4.0.0",
                 "pathtrace": "^2.2.0",
                 "smob": "^1.6.1"
@@ -159,19 +162,20 @@
             }
         },
         "node_modules/@authup/core-http-kit": {
-            "version": "1.0.0-beta.52",
-            "resolved": "https://registry.npmjs.org/@authup/core-http-kit/-/core-http-kit-1.0.0-beta.52.tgz",
-            "integrity": "sha512-EneuExXOZ7jgyneKB/6Q7uFei0OAKV+lXaRHTQloSjMs+g7t97xiziW5hlWcbLPKSieyHz60tSEOYvy5To47yg==",
+            "version": "1.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@authup/core-http-kit/-/core-http-kit-1.0.0-beta.54.tgz",
+            "integrity": "sha512-uSI7EllG65pKXQOEHBMmtX8EOWzRoLhPbiBOZvuG+UFTEO5Q6yIB9vgaDmH01MaVVvCRtpjpBxrg4FZoPRM+1Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/access": "^1.0.0-beta.52",
-                "@authup/core-kit": "^1.0.0-beta.52",
-                "@authup/kit": "^1.0.0-beta.52",
-                "@authup/specs": "^1.0.0-beta.52",
+                "@authup/access": "^1.0.0-beta.54",
+                "@authup/core-kit": "^1.0.0-beta.54",
+                "@authup/kit": "^1.0.0-beta.54",
+                "@authup/specs": "^1.0.0-beta.54",
                 "@hapic/oauth2": "^4.0.1",
                 "@posva/event-emitter": "^1.0.3",
-                "hapic": "^3.0.1",
-                "rapiq": "^0.9.0"
+                "@rapiq/codec-url": "^2.0.0-beta.7",
+                "@rapiq/core": "^2.0.0-beta.7",
+                "hapic": "^3.0.1"
             },
             "engines": {
                 "node": "^22.13.0 || ^23.5.0 || >=24.0.0"
@@ -204,14 +208,14 @@
             }
         },
         "node_modules/@authup/core-kit": {
-            "version": "1.0.0-beta.52",
-            "resolved": "https://registry.npmjs.org/@authup/core-kit/-/core-kit-1.0.0-beta.52.tgz",
-            "integrity": "sha512-uMFa2uzazv5iMHpo7PJvmbboSM68TlDebf9BWKnkU8SnunIzj4kZeeeaYc/6251AMuIza9Za/FNEBd8gpTNRKg==",
+            "version": "1.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@authup/core-kit/-/core-kit-1.0.0-beta.54.tgz",
+            "integrity": "sha512-UyRDzm6vCngBgnvVKw+a3DZwg5CWBjhs21KJCbjnSHWN9m698ZjSQy/Nvq25RAZDaeSSaTsO2zXFqofvWu9MVQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/errors": "^1.0.0-beta.52",
-                "@authup/kit": "^1.0.0-beta.52",
-                "@authup/specs": "^1.0.0-beta.52",
+                "@authup/errors": "^1.0.0-beta.54",
+                "@authup/kit": "^1.0.0-beta.54",
+                "@authup/specs": "^1.0.0-beta.54",
                 "@validup/zod": "^0.3.3",
                 "validup": "^0.5.1",
                 "zod": "^4.4.3"
@@ -221,12 +225,12 @@
             }
         },
         "node_modules/@authup/core-realtime-kit": {
-            "version": "1.0.0-beta.52",
-            "resolved": "https://registry.npmjs.org/@authup/core-realtime-kit/-/core-realtime-kit-1.0.0-beta.52.tgz",
-            "integrity": "sha512-v1nm+Zq7tz+ngEiBoRAG3cdZiI+vg3xYDv4b5MKfK1JXCWkOBhrvsTLxswiTExkXWqr2wWXnG5N8JXaHpYN5TA==",
+            "version": "1.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@authup/core-realtime-kit/-/core-realtime-kit-1.0.0-beta.54.tgz",
+            "integrity": "sha512-AxCw8y/LZIeks5FdwSFdJakbNQliRVO6tFmL3rL/tMJvFC6Jk/0lkWJvMNa8V48xYDJnWIVM8zookn2O5BIFeg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/kit": "^1.0.0-beta.52"
+                "@authup/kit": "^1.0.0-beta.54"
             },
             "engines": {
                 "node": "^22.13.0 || ^23.5.0 || >=24.0.0"
@@ -236,9 +240,9 @@
             }
         },
         "node_modules/@authup/errors": {
-            "version": "1.0.0-beta.52",
-            "resolved": "https://registry.npmjs.org/@authup/errors/-/errors-1.0.0-beta.52.tgz",
-            "integrity": "sha512-Dm7DOI+P8MQNbJUdT/hhquZhpKnhHTuyDs4TIVzyi8hTvSI8ZMMRGHKbg1SQ2bQ/hCfl0q5EHJX7cgfmKo06gQ==",
+            "version": "1.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@authup/errors/-/errors-1.0.0-beta.54.tgz",
+            "integrity": "sha512-V43K+Q0mwv4D7uMnwW762bZHhiALKGbt5fP7A9/53KlAD0YwvXkZlFFGysYVVprm0zIhboY9Y2ahEijefnvcYw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ebec/core": "^1.1.0",
@@ -249,12 +253,12 @@
             }
         },
         "node_modules/@authup/i18n": {
-            "version": "1.0.0-beta.52",
-            "resolved": "https://registry.npmjs.org/@authup/i18n/-/i18n-1.0.0-beta.52.tgz",
-            "integrity": "sha512-nkRzFoBFYUDjEuBVixWvtRZm55CKt80MxY9/Fi4mz+yFQ5Li+WZN6xpqRh6kqwgY+BjoYPc77qD0UDGSY3s2Vg==",
+            "version": "1.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@authup/i18n/-/i18n-1.0.0-beta.54.tgz",
+            "integrity": "sha512-nAic8nna0gPRna/V8Xnr1BwDod3CF9G7gGXWMAzM+cSbHtJzkJHeck7ttVHCc8X4ty7eRJ8BvLbm06IzUjX5Aw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/errors": "^1.0.0-beta.52",
+                "@authup/errors": "^1.0.0-beta.54",
                 "ilingo": "^6.0.0"
             },
             "engines": {
@@ -270,22 +274,22 @@
             }
         },
         "node_modules/@authup/kit": {
-            "version": "1.0.0-beta.52",
-            "resolved": "https://registry.npmjs.org/@authup/kit/-/kit-1.0.0-beta.52.tgz",
-            "integrity": "sha512-P/jkuOJvdKgNSI4LjkaevZ/sWqeSy3g6oBlV26VLcD955E2NCv7HCLvsCu7wQrahDZFbACSja+BMtolP+Oqelw==",
+            "version": "1.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@authup/kit/-/kit-1.0.0-beta.54.tgz",
+            "integrity": "sha512-Pp9Jux+UJHJB8Mu+pKsEmC0amn4s0rI7sPmaNPYNGinb6YUtt8Ccqvikik8NT5sGmwBNP5fdiG+TGPvI0rJSsg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "destr": "^2.0.3",
-                "nanoid": "^5.1.16"
+                "nanoid": "^6.0.0"
             },
             "engines": {
                 "node": "^22.13.0 || ^23.5.0 || >=24.0.0"
             }
         },
         "node_modules/@authup/kit/node_modules/nanoid": {
-            "version": "5.1.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
-            "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-6.0.0.tgz",
+            "integrity": "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ==",
             "funding": [
                 {
                     "type": "github",
@@ -297,17 +301,17 @@
                 "nanoid": "bin/nanoid.js"
             },
             "engines": {
-                "node": "^18 || >=20"
+                "node": "^22 || ^24 || >=26"
             }
         },
         "node_modules/@authup/specs": {
-            "version": "1.0.0-beta.52",
-            "resolved": "https://registry.npmjs.org/@authup/specs/-/specs-1.0.0-beta.52.tgz",
-            "integrity": "sha512-rQK33CMw6jA1NdIgy0IqiYZfbGNvVpmqDkDT+/DtUHJVP0Bxz5dhPElKybCaJlpvmB04NH1wFriqBCX9U+L/pw==",
+            "version": "1.0.0-beta.54",
+            "resolved": "https://registry.npmjs.org/@authup/specs/-/specs-1.0.0-beta.54.tgz",
+            "integrity": "sha512-F2aXIVvcgjctkUMfAsTbfWmGYSuBLpoQGtzV59PaGgan2aQqvYExM/mHo79GG32klHQfUWh/RuaPGbXQwkpevg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@authup/errors": "^1.0.0-beta.52",
-                "@authup/kit": "^1.0.0-beta.52",
+                "@authup/errors": "^1.0.0-beta.54",
+                "@authup/kit": "^1.0.0-beta.54",
                 "pathtrace": "^2.2.0",
                 "smob": "^1.6.1"
             },
@@ -6009,6 +6013,72 @@
                 "url": "https://github.com/sponsors/sxzz"
             }
         },
+        "node_modules/@rapiq/codec-url": {
+            "version": "2.0.0-beta.7",
+            "resolved": "https://registry.npmjs.org/@rapiq/codec-url/-/codec-url-2.0.0-beta.7.tgz",
+            "integrity": "sha512-MBkmMxMCU5vYoSe8ToNBXnU+3u4XUeXvrNidpy7YXArOkF3McvuZIe46X95OVoSRdWdfnmMkDbQG6FXjnHtNEQ==",
+            "license": "MIT",
+            "dependencies": {
+                "qs": "^6.15.3"
+            },
+            "peerDependencies": {
+                "@rapiq/core": "^2.0.0-beta.7",
+                "@rapiq/parser-expression": "^2.0.0-beta.7",
+                "@rapiq/parser-simple": "^2.0.0-beta.7"
+            }
+        },
+        "node_modules/@rapiq/core": {
+            "version": "2.0.0-beta.7",
+            "resolved": "https://registry.npmjs.org/@rapiq/core/-/core-2.0.0-beta.7.tgz",
+            "integrity": "sha512-vxxgNyhHH+QwtVOiruZOBdllJipGTaC/PHLUgPmgu/QgkWZSdvmGif8crfW3RMdOJpMSEuX4b3MReYUWHU+ihg==",
+            "license": "MIT",
+            "dependencies": {
+                "pathtrace": "^2.2.0"
+            }
+        },
+        "node_modules/@rapiq/memory": {
+            "version": "2.0.0-beta.7",
+            "resolved": "https://registry.npmjs.org/@rapiq/memory/-/memory-2.0.0-beta.7.tgz",
+            "integrity": "sha512-hvLwlJXIREJynPrDMN1d/cvd9nQS3Tg2kkIfiMz5u7cg0W/yz5da7dh80cL0p2SFIggUJ78FzIYZBM2ZwQ2sEQ==",
+            "license": "MIT",
+            "dependencies": {
+                "smob": "^1.6.2"
+            },
+            "peerDependencies": {
+                "@rapiq/core": "^2.0.0-beta.7"
+            }
+        },
+        "node_modules/@rapiq/parser-expression": {
+            "version": "2.0.0-beta.7",
+            "resolved": "https://registry.npmjs.org/@rapiq/parser-expression/-/parser-expression-2.0.0-beta.7.tgz",
+            "integrity": "sha512-ge4K6+pjY5553xkKV6MY+tc5Abl8GmzmayJoGNq8o7I3jcanAIIF/uNkPD3zYSz0vlbTdQyd7zOMJhcBvbTeKw==",
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "@rapiq/core": "^2.0.0-beta.7",
+                "@rapiq/parser-simple": "^2.0.0-beta.7"
+            }
+        },
+        "node_modules/@rapiq/parser-mongo": {
+            "version": "2.0.0-beta.7",
+            "resolved": "https://registry.npmjs.org/@rapiq/parser-mongo/-/parser-mongo-2.0.0-beta.7.tgz",
+            "integrity": "sha512-1cBg97wds+A+cPCCksKuJnC4CSMnE/netnSIuJs1QRD6z4I6NfzOY20PaCndoyLBg3YiI9H2pgFsv3zbEnjTcA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@rapiq/core": "^2.0.0-beta.7",
+                "@rapiq/parser-simple": "^2.0.0-beta.7"
+            }
+        },
+        "node_modules/@rapiq/parser-simple": {
+            "version": "2.0.0-beta.7",
+            "resolved": "https://registry.npmjs.org/@rapiq/parser-simple/-/parser-simple-2.0.0-beta.7.tgz",
+            "integrity": "sha512-4EVBes17IGtp284nyHx+UhwfucT4GzO+pNbVhSTeU0iqx2OxwnRWj+88Pyz7Aq/YkaKawNdtShqMHwPtbMN8XA==",
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "@rapiq/core": "^2.0.0-beta.7"
+            }
+        },
         "node_modules/@rolldown/binding-android-arm64": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
@@ -6986,6 +7056,12 @@
             "funding": {
                 "url": "https://ko-fi.com/dangreen"
             }
+        },
+        "node_modules/@simplewebauthn/browser": {
+            "version": "13.3.0",
+            "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+            "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+            "license": "MIT"
         },
         "node_modules/@sindresorhus/is": {
             "version": "7.2.0",
@@ -8172,41 +8248,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@ucast/core": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@ucast/core/-/core-2.0.0.tgz",
-            "integrity": "sha512-4XVx6LzPXZGvnZO5jp39cm/G4UvuwvEdtmg+9+4+zl6uFkCcB7UJacvtMYeBE56GJVT99Zqy6Pii7dGJq3Kz9Q==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@ucast/js": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@ucast/js/-/js-4.0.1.tgz",
-            "integrity": "sha512-9O5xPBvwEWQk2WvO69Eh2WJB8QljVZ2vRVdFvfnKjlZwWXcYxp1lqLBhwXBU1AtuSgCvKhJPkXdjKJggUmAmQQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ucast/core": "2.0.0"
-            }
-        },
-        "node_modules/@ucast/mongo": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-3.0.0.tgz",
-            "integrity": "sha512-kwuSH+kdB4GCR0LGhy/PEDm4PCflur89AlK82kNiYD0FvsA8A/p+0sx7m+/R8mMFAlmlkAd3VXp7sM/cLLYWYg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ucast/core": "2.0.0"
-            }
-        },
-        "node_modules/@ucast/mongo2js": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-2.0.0.tgz",
-            "integrity": "sha512-vNBZzRnsfLr/TSxEoxz6W6hHQ5tmWsfEeC0nCq5z8RezC1AqIRy3cfHm8AGvlGtcn+cTSFQcZremfqnz6wm+nQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ucast/core": "2.0.0",
-                "@ucast/js": "4.0.1",
-                "@ucast/mongo": "3.0.0"
-            }
-        },
         "node_modules/@unhead/vue": {
             "version": "2.1.15",
             "dev": true,
@@ -8948,12 +8989,13 @@
             }
         },
         "node_modules/@vuecs/forms": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/@vuecs/forms/-/forms-5.3.2.tgz",
-            "integrity": "sha512-he8x6TegfMet7XJ+l7g6PK0rQ8YZhKNGU+jxEsiJDaXhRltm2pbb/QgaFQgNkHfWArA3bk7red/vofj6eVaTXQ==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/@vuecs/forms/-/forms-5.3.3.tgz",
+            "integrity": "sha512-EEe0W2PukRH4qtMLCRsVK6tk4FLhgN1Qb9s7Ln85zWlr00H/eue6thYtn+tO7CyUHkHJL/zOq41v1+QTH6CC0Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@vueuse/core": "^14.3.0",
+                "ohash": "^2.0.11",
                 "reka-ui": "^2.10.1"
             },
             "engines": {
@@ -9143,9 +9185,9 @@
             }
         },
         "node_modules/@vuecs/theme-tailwind": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@vuecs/theme-tailwind/-/theme-tailwind-6.3.0.tgz",
-            "integrity": "sha512-R1LjIjkUMI77BPhYxhMrrhg8wn7VaBFboeNF9awrWUE9eQDCeBIprNzh1FVV1Ay0FRPuB7q0kLCo7xaM5Ir06A==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/@vuecs/theme-tailwind/-/theme-tailwind-6.3.1.tgz",
+            "integrity": "sha512-b27iOKc/olFtrzngsv20Op6ye+9/ZLCwSEAy42mKLRH9Js5Cyp/OR9svEURXRmV5eE6glhvYw+CfJRadr0mREQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tailwind-merge": "^3.6.0"
@@ -10519,7 +10561,6 @@
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -10527,6 +10568,22 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/callsites": {
@@ -11613,7 +11670,6 @@
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -11792,7 +11848,6 @@
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -11800,7 +11855,6 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -11813,7 +11867,6 @@
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -12656,7 +12709,6 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
-            "devOptional": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -12708,7 +12760,6 @@
         },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -12736,7 +12787,6 @@
         },
         "node_modules/get-proto": {
             "version": "1.0.1",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
@@ -12880,7 +12930,6 @@
         },
         "node_modules/gopd": {
             "version": "1.2.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -12946,7 +12995,6 @@
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -12973,7 +13021,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
             "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -14448,7 +14495,6 @@
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -16115,6 +16161,18 @@
                 "node": ">=18"
             }
         },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/obug": {
             "version": "2.1.3",
             "dev": true,
@@ -17259,6 +17317,22 @@
                 "node": ">=6"
             }
         },
+        "node_modules/qs": {
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/quansync": {
             "version": "1.0.0",
             "dev": true,
@@ -17304,25 +17378,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/rapiq": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/rapiq/-/rapiq-0.9.0.tgz",
-            "integrity": "sha512-k4oT4RarFBrlLMJ49xUTeQpa/us0uU4I70D/UEnK3FWQ4GENzei01rEQAmvPKAIzACo4NMW+YcYJ7EVfSa7EFg==",
-            "license": "MIT",
-            "dependencies": {
-                "ebec": "^1.1.0",
-                "smob": "^1.4.0"
-            }
-        },
-        "node_modules/rapiq/node_modules/ebec": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ebec/-/ebec-1.1.1.tgz",
-            "integrity": "sha512-JZ1vcvPQtR+8LGbZmbjG21IxLQq/v47iheJqn2F6yB2CgnGfn8ZVg3myHrf3buIZS8UCwQK0jOSIb3oHX7aH8g==",
-            "license": "MIT",
-            "dependencies": {
-                "smob": "^1.4.0"
             }
         },
         "node_modules/rc9": {
@@ -18149,6 +18204,78 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/side-channel": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/siginfo": {
             "version": "2.0.0",
             "dev": true,
@@ -18310,9 +18437,9 @@
             }
         },
         "node_modules/socket.io-parser": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-            "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+            "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -21452,8 +21579,8 @@
             "version": "1.10.1",
             "license": "MIT",
             "dependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.52",
-                "@authup/core-kit": "^1.0.0-beta.52",
+                "@authup/client-web-kit": "^1.0.0-beta.54",
+                "@authup/core-kit": "^1.0.0-beta.54",
                 "@dnpm-dip/core": "^1.11.0",
                 "@dnpm-dip/kit": "^1.10.0",
                 "@nuxt/kit": "^4.4.5",
@@ -22120,8 +22247,8 @@
                 "ufo": "^1.6.2"
             },
             "devDependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.52",
-                "@authup/core-http-kit": "^1.0.0-beta.52",
+                "@authup/client-web-kit": "^1.0.0-beta.54",
+                "@authup/core-http-kit": "^1.0.0-beta.54",
                 "@ilingo/validup": "^1.0.1",
                 "@ilingo/validup-vue": "^1.0.1",
                 "@ilingo/vue": "^6.0.0",
@@ -22150,8 +22277,8 @@
                 "zod": "^4.3.6"
             },
             "peerDependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.52",
-                "@authup/core-http-kit": "^1.0.0-beta.52",
+                "@authup/client-web-kit": "^1.0.0-beta.54",
+                "@authup/core-http-kit": "^1.0.0-beta.54",
                 "@ilingo/validup": "^1.x",
                 "@ilingo/validup-vue": "^1.x",
                 "@ilingo/vue": "^6.x",
@@ -22206,7 +22333,7 @@
             "version": "1.35.0",
             "license": "MIT",
             "dependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.52",
+                "@authup/client-web-kit": "^1.0.0-beta.54",
                 "@dnpm-dip/core": "^1.35.0",
                 "@dnpm-dip/kit": "^1.28.1",
                 "@nuxt/kit": "^4.4.5"
@@ -22881,12 +23008,12 @@
             "name": "@dnpm-dip/portal",
             "version": "1.34.0",
             "devDependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.52",
-                "@authup/client-web-kit-theme": "^1.0.0-beta.52",
-                "@authup/client-web-nuxt": "^1.0.0-beta.52",
-                "@authup/core-http-kit": "^1.0.0-beta.52",
-                "@authup/core-kit": "^1.0.0-beta.52",
-                "@authup/kit": "^1.0.0-beta.52",
+                "@authup/client-web-kit": "^1.0.0-beta.54",
+                "@authup/client-web-kit-theme": "^1.0.0-beta.54",
+                "@authup/client-web-nuxt": "^1.0.0-beta.54",
+                "@authup/core-http-kit": "^1.0.0-beta.54",
+                "@authup/core-kit": "^1.0.0-beta.54",
+                "@authup/kit": "^1.0.0-beta.54",
                 "@dnpm-dip/core": "^1.35.0",
                 "@dnpm-dip/kit": "^1.28.1",
                 "@dnpm-dip/mtb": "^1.35.0",
@@ -22954,7 +23081,7 @@
             "version": "1.34.0",
             "license": "MIT",
             "dependencies": {
-                "@authup/client-web-kit": "^1.0.0-beta.52",
+                "@authup/client-web-kit": "^1.0.0-beta.54",
                 "@dnpm-dip/core": "^1.35.0",
                 "@dnpm-dip/kit": "^1.28.1",
                 "@nuxt/kit": "^4.4.5"
@@ -23627,7 +23754,7 @@
             "version": "1.35.0",
             "license": "MIT",
             "dependencies": {
-                "@authup/client-web-kit-theme": "^1.0.0-beta.52",
+                "@authup/client-web-kit-theme": "^1.0.0-beta.54",
                 "@vuecs/design": "^1.0.8",
                 "@vuecs/theme-tailwind": "^6.1.1"
             },

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -30,8 +30,8 @@
         "test:watch": "vitest watch"
     },
     "dependencies": {
-        "@authup/core-kit": "^1.0.0-beta.52",
-        "@authup/client-web-kit": "^1.0.0-beta.52",
+        "@authup/core-kit": "^1.0.0-beta.54",
+        "@authup/client-web-kit": "^1.0.0-beta.54",
         "@dnpm-dip/core": "^1.11.0",
         "@dnpm-dip/kit": "^1.10.0",
         "@nuxt/kit": "^4.4.5",

--- a/packages/admin/src/runtime/pages/clients/[id]/index.vue
+++ b/packages/admin/src/runtime/pages/clients/[id]/index.vue
@@ -40,7 +40,7 @@ export default defineNuxtComponent({
         </h6>
         <AClientForm
             :entity="entity"
-            :realm-id="entity.realm_id"
+            :realm-id="entity.realmId"
             @updated="handleUpdated"
             @failed="handleFailed"
         />

--- a/packages/admin/src/runtime/pages/clients/[id]/roles.vue
+++ b/packages/admin/src/runtime/pages/clients/[id]/roles.vue
@@ -26,7 +26,7 @@ export default defineNuxtComponent({
 <template>
     <AClientRoleAssignments
         :entity-id="entity.id"
-        :realm-id="entity.realm_id"
+        :realm-id="entity.realmId"
     >
         <template #header="props">
             <ASearch

--- a/packages/admin/src/runtime/pages/clients/[id]/url.vue
+++ b/packages/admin/src/runtime/pages/clients/[id]/url.vue
@@ -3,7 +3,7 @@
 import { AClientScopes } from '@authup/client-web-kit';
 import type { Client, ClientScope } from '@authup/core-kit';
 import { VCFormGroup, VCFormInput, VCFormSwitch } from '@vuecs/forms';
-import type { BuildInput } from 'rapiq';
+import type { EntityListQueryInput } from '@authup/client-web-kit';
 import { computed, ref } from 'vue';
 import type { PropType } from 'vue';
 import { useRuntimeConfig } from '#app';
@@ -55,9 +55,9 @@ export default defineNuxtComponent({
             }
         };
 
-        const query = computed<BuildInput<ClientScope>>(() => ({
-            filter: { client_id: props.entity.id },
-            include: ['scope'],
+        const query = computed<EntityListQueryInput<ClientScope>>(() => ({
+            filters: { clientId: props.entity.id },
+            relations: ['scope'],
         }));
 
         return {

--- a/packages/admin/src/runtime/pages/clients/index/index.vue
+++ b/packages/admin/src/runtime/pages/clients/index/index.vue
@@ -13,7 +13,7 @@ import {
     storeToRefs,
     usePermissionCheck,
 } from '@authup/client-web-kit';
-import type { BuildInput } from 'rapiq';
+import type { EntityListQueryInput } from '@authup/client-web-kit';
 import { VCButton } from '@vuecs/button';
 import { VCIcon } from '@vuecs/icon';
 import { VCTimeago } from '@vuecs/timeago';
@@ -42,7 +42,7 @@ export default defineNuxtComponent({
         const store = injectStore();
         const { realmManagementId } = storeToRefs(store);
 
-        const query : BuildInput<Client> = { filter: { realm_id: [realmManagementId.value, null] } };
+        const query : EntityListQueryInput<Client> = { filters: { realmId: [realmManagementId.value, null] } };
 
         const hasEditPermission = usePermissionCheck({ name: PermissionName.CLIENT_UPDATE });
         const hasDropPermission = usePermissionCheck({ name: PermissionName.CLIENT_DELETE });
@@ -61,25 +61,25 @@ export default defineNuxtComponent({
                 cellClass: 'text-center',
             },
             {
-                key: 'is_confidential',
-                label: 'Vertraulich',
+                key: 'authMethod',
+                label: 'Auth-Methode',
                 headerClass: 'text-center',
                 cellClass: 'text-center',
             },
             {
-                key: 'built_in',
+                key: 'builtIn',
                 label: 'Integriert',
                 headerClass: 'text-center',
                 cellClass: 'text-center',
             },
             {
-                key: 'created_at',
+                key: 'createdAt',
                 label: 'Erstelldatum',
                 headerClass: 'text-center',
                 cellClass: 'text-center',
             },
             {
-                key: 'updated_at',
+                key: 'updatedAt',
                 label: 'Aktualisierungsdatum',
                 headerClass: 'text-center',
                 cellClass: 'text-center',
@@ -128,8 +128,8 @@ export default defineNuxtComponent({
                 :busy="props.busy"
             >
                 <template #cell-name="{ row }: { row: any }">
-                    <template v-if="row.display_name">
-                        {{ row.display_name }} <span class="text-fg-muted">({{ row.name }})</span>
+                    <template v-if="row.displayName">
+                        {{ row.displayName }} <span class="text-fg-muted">({{ row.name }})</span>
                     </template>
                     <template v-else>
                         {{ row.name }}
@@ -141,23 +141,22 @@ export default defineNuxtComponent({
                         :class="row.active ? 'text-success-600' : 'text-error-600'"
                     />
                 </template>
-                <template #cell-is_confidential="{ row }: { row: any }">
+                <template #cell-authMethod="{ row }: { row: any }">
+                    <span class="rounded-full border border-border bg-bg px-2 py-0.5 text-xs">
+                        {{ row.authMethod }}
+                    </span>
+                </template>
+                <template #cell-builtIn="{ row }: { row: any }">
                     <VCIcon
-                        :name="row.is_confidential ? 'fa6-solid:check' : 'fa6-solid:xmark'"
-                        :class="row.is_confidential ? 'text-success-600' : 'text-error-600'"
+                        :name="row.builtIn ? 'fa6-solid:check' : 'fa6-solid:xmark'"
+                        :class="row.builtIn ? 'text-success-600' : 'text-error-600'"
                     />
                 </template>
-                <template #cell-built_in="{ row }: { row: any }">
-                    <VCIcon
-                        :name="row.built_in ? 'fa6-solid:check' : 'fa6-solid:xmark'"
-                        :class="row.built_in ? 'text-success-600' : 'text-error-600'"
-                    />
+                <template #cell-createdAt="{ row }: { row: any }">
+                    <VCTimeago :datetime="row.createdAt" />
                 </template>
-                <template #cell-created_at="{ row }: { row: any }">
-                    <VCTimeago :datetime="row.created_at" />
-                </template>
-                <template #cell-updated_at="{ row }: { row: any }">
-                    <VCTimeago :datetime="row.updated_at" />
+                <template #cell-updatedAt="{ row }: { row: any }">
+                    <VCTimeago :datetime="row.updatedAt" />
                 </template>
                 <template #cell-options="{ row }: { row: any }">
                     <div class="flex items-center gap-1">

--- a/packages/admin/src/runtime/pages/identity-providers/[id]/index.vue
+++ b/packages/admin/src/runtime/pages/identity-providers/[id]/index.vue
@@ -50,7 +50,7 @@ export default defineNuxtComponent({
     <template v-if="entity.protocol === 'ldap'">
         <AIdentityProviderLdapForm
             :entity="entity"
-            :realm-id="entity.realm_id"
+            :realm-id="entity.realmId"
             @updated="handleUpdated"
             @failed="handleFailed"
         />
@@ -59,7 +59,7 @@ export default defineNuxtComponent({
         <AIdentityProviderOAuth2Form
             :api-url="apiUrl"
             :entity="entity"
-            :realm-id="entity.realm_id"
+            :realm-id="entity.realmId"
             @updated="handleUpdated"
             @failed="handleFailed"
         />

--- a/packages/admin/src/runtime/pages/identity-providers/index/index.vue
+++ b/packages/admin/src/runtime/pages/identity-providers/index/index.vue
@@ -16,7 +16,7 @@ import {
     storeToRefs,
     usePermissionCheck,
 } from '@authup/client-web-kit';
-import type { BuildInput } from 'rapiq';
+import type { EntityListQueryInput } from '@authup/client-web-kit';
 import { resolveComponent } from 'vue';
 import { defineNuxtComponent } from '#app';
 
@@ -42,7 +42,7 @@ export default defineNuxtComponent({
         const store = injectStore();
         const { realmManagementId } = storeToRefs(store);
 
-        const query : BuildInput<IdentityProvider> = { filter: { realm_id: [realmManagementId.value, null] } };
+        const query : EntityListQueryInput<IdentityProvider> = { filters: { realmId: [realmManagementId.value, null] } };
 
         const hasEditPermission = usePermissionCheck({ name: PermissionName.IDENTITY_PROVIDER_UPDATE });
         const hasDropPermission = usePermissionCheck({ name: PermissionName.IDENTITY_PROVIDER_DELETE });
@@ -55,13 +55,13 @@ export default defineNuxtComponent({
                 cellClass: 'text-left',
             },
             {
-                key: 'created_at',
+                key: 'createdAt',
                 label: 'Erstelldatum',
                 headerClass: 'text-center',
                 cellClass: 'text-center',
             },
             {
-                key: 'updated_at',
+                key: 'updatedAt',
                 label: 'Aktualisierungsdatum',
                 headerClass: 'text-left',
                 cellClass: 'text-left',
@@ -109,11 +109,11 @@ export default defineNuxtComponent({
                 :columns="columns"
                 :busy="props.busy"
             >
-                <template #cell-created_at="{ row }: { row: any }">
-                    <VCTimeago :datetime="row.created_at" />
+                <template #cell-createdAt="{ row }: { row: any }">
+                    <VCTimeago :datetime="row.createdAt" />
                 </template>
-                <template #cell-updated_at="{ row }: { row: any }">
-                    <VCTimeago :datetime="row.updated_at" />
+                <template #cell-updatedAt="{ row }: { row: any }">
+                    <VCTimeago :datetime="row.updatedAt" />
                 </template>
                 <template #cell-options="{ row }: { row: any }">
                     <div class="flex items-center gap-1">

--- a/packages/admin/src/runtime/pages/roles/[id]/permissions.vue
+++ b/packages/admin/src/runtime/pages/roles/[id]/permissions.vue
@@ -35,8 +35,8 @@ export default defineNuxtComponent({
         <template #item="{ data }">
             <div class="flex flex-col w-full">
                 <div>
-                    <template v-if="data.display_name">
-                        <strong>{{ data.display_name }}</strong> ({{ data.name }})
+                    <template v-if="data.displayName">
+                        <strong>{{ data.displayName }}</strong> ({{ data.name }})
                     </template>
                     <template v-else>
                         <strong>{{ data.name }}</strong>

--- a/packages/admin/src/runtime/pages/roles/index/index.vue
+++ b/packages/admin/src/runtime/pages/roles/index/index.vue
@@ -13,7 +13,7 @@ import {
     storeToRefs,
     usePermissionCheck,
 } from '@authup/client-web-kit';
-import type { BuildInput } from 'rapiq';
+import type { EntityListQueryInput } from '@authup/client-web-kit';
 import { VCButton } from '@vuecs/button';
 import { VCIcon } from '@vuecs/icon';
 import { VCTimeago } from '@vuecs/timeago';
@@ -42,7 +42,7 @@ export default defineNuxtComponent({
         const store = injectStore();
         const { realmManagementId } = storeToRefs(store);
 
-        const query : BuildInput<Role> = { filter: { realm_id: [realmManagementId.value, null] } };
+        const query : EntityListQueryInput<Role> = { filters: { realmId: [realmManagementId.value, null] } };
 
         const hasEditPermission = usePermissionCheck({ name: PermissionName.ROLE_UPDATE });
         const hasDropPermission = usePermissionCheck({ name: PermissionName.ROLE_DELETE });
@@ -55,13 +55,13 @@ export default defineNuxtComponent({
                 cellClass: 'text-left',
             },
             {
-                key: 'created_at',
+                key: 'createdAt',
                 label: 'Erstelldatum',
                 headerClass: 'text-center',
                 cellClass: 'text-center',
             },
             {
-                key: 'updated_at',
+                key: 'updatedAt',
                 label: 'Aktualisierungsdatum',
                 headerClass: 'text-left',
                 cellClass: 'text-left',
@@ -110,18 +110,18 @@ export default defineNuxtComponent({
                 :busy="props.busy"
             >
                 <template #cell-name="{ row }: { row: any }">
-                    <template v-if="row.display_name">
-                        {{ row.display_name }} <span class="text-fg-muted">({{ row.name }})</span>
+                    <template v-if="row.displayName">
+                        {{ row.displayName }} <span class="text-fg-muted">({{ row.name }})</span>
                     </template>
                     <template v-else>
                         {{ row.name }}
                     </template>
                 </template>
-                <template #cell-created_at="{ row }: { row: any }">
-                    <VCTimeago :datetime="row.created_at" />
+                <template #cell-createdAt="{ row }: { row: any }">
+                    <VCTimeago :datetime="row.createdAt" />
                 </template>
-                <template #cell-updated_at="{ row }: { row: any }">
-                    <VCTimeago :datetime="row.updated_at" />
+                <template #cell-updatedAt="{ row }: { row: any }">
+                    <VCTimeago :datetime="row.updatedAt" />
                 </template>
                 <template #cell-options="{ row }: { row: any }">
                     <div class="flex items-center gap-1">

--- a/packages/admin/src/runtime/pages/users/[id]/index.vue
+++ b/packages/admin/src/runtime/pages/users/[id]/index.vue
@@ -48,7 +48,7 @@ export default defineNuxtComponent({
 
             <AUserForm
                 :entity="entity"
-                :realm-id="entity.realm_id"
+                :realm-id="entity.realmId"
                 @updated="handleUpdated"
                 @failed="handleFailed"
             />

--- a/packages/admin/src/runtime/pages/users/[id]/permissions.vue
+++ b/packages/admin/src/runtime/pages/users/[id]/permissions.vue
@@ -33,8 +33,8 @@ export default defineNuxtComponent({
         <template #item="{ data }">
             <div class="flex flex-col w-full">
                 <div>
-                    <template v-if="data.display_name">
-                        <strong>{{ data.display_name }}</strong> ({{ data.name }})
+                    <template v-if="data.displayName">
+                        <strong>{{ data.displayName }}</strong> ({{ data.name }})
                     </template>
                     <template v-else>
                         <strong>{{ data.name }}</strong>

--- a/packages/admin/src/runtime/pages/users/[id]/roles.vue
+++ b/packages/admin/src/runtime/pages/users/[id]/roles.vue
@@ -33,8 +33,8 @@ export default defineNuxtComponent({
         <template #item="{ data }">
             <div class="flex flex-col w-full">
                 <div>
-                    <template v-if="data.display_name">
-                        <strong>{{ data.display_name }}</strong> ({{ data.name }})
+                    <template v-if="data.displayName">
+                        <strong>{{ data.displayName }}</strong> ({{ data.name }})
                     </template>
                     <template v-else>
                         <strong>{{ data.name }}</strong>

--- a/packages/admin/src/runtime/pages/users/index/index.vue
+++ b/packages/admin/src/runtime/pages/users/index/index.vue
@@ -14,7 +14,7 @@ import {
     storeToRefs,
     usePermissionCheck,
 } from '@authup/client-web-kit';
-import type { BuildInput } from 'rapiq';
+import type { EntityListQueryInput } from '@authup/client-web-kit';
 import { VCButton } from '@vuecs/button';
 import { VCIcon } from '@vuecs/icon';
 import { VCTimeago } from '@vuecs/timeago';
@@ -43,7 +43,7 @@ export default defineNuxtComponent({
         const store = injectStore();
         const { realmManagementId } = storeToRefs(store);
 
-        const query : BuildInput<User> = { filter: { realm_id: [realmManagementId.value, null] } };
+        const query : EntityListQueryInput<User> = { filters: { realmId: [realmManagementId.value, null] } };
 
         const hasEditPermission = usePermissionCheck({ name: PermissionName.USER_UPDATE });
         const hasDropPermission = usePermissionCheck({ name: PermissionName.USER_DELETE });
@@ -56,13 +56,13 @@ export default defineNuxtComponent({
                 cellClass: 'text-left',
             },
             {
-                key: 'created_at',
+                key: 'createdAt',
                 label: 'Erstelldatum',
                 headerClass: 'text-center',
                 cellClass: 'text-center',
             },
             {
-                key: 'updated_at',
+                key: 'updatedAt',
                 label: 'Aktualisierungsdatum',
                 headerClass: 'text-left',
                 cellClass: 'text-left',
@@ -112,11 +112,11 @@ export default defineNuxtComponent({
                 :columns="columns"
                 :busy="props.busy"
             >
-                <template #cell-created_at="{ row }: { row: any }">
-                    <VCTimeago :datetime="row.created_at" />
+                <template #cell-createdAt="{ row }: { row: any }">
+                    <VCTimeago :datetime="row.createdAt" />
                 </template>
-                <template #cell-updated_at="{ row }: { row: any }">
-                    <VCTimeago :datetime="row.updated_at" />
+                <template #cell-updatedAt="{ row }: { row: any }">
+                    <VCTimeago :datetime="row.updatedAt" />
                 </template>
                 <template #cell-options="{ row }: { row: any }">
                     <div class="flex items-center gap-1">

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,8 +47,8 @@
         "ufo": "^1.6.2"
     },
     "devDependencies": {
-        "@authup/core-http-kit": "^1.0.0-beta.52",
-        "@authup/client-web-kit": "^1.0.0-beta.52",
+        "@authup/core-http-kit": "^1.0.0-beta.54",
+        "@authup/client-web-kit": "^1.0.0-beta.54",
         "chart.js": "^4.5.1",
         "@ilingo/validup": "^1.0.1",
         "@ilingo/validup-vue": "^1.0.1",
@@ -77,8 +77,8 @@
         "zod": "^4.3.6"
     },
     "peerDependencies": {
-        "@authup/core-http-kit": "^1.0.0-beta.52",
-        "@authup/client-web-kit": "^1.0.0-beta.52",
+        "@authup/core-http-kit": "^1.0.0-beta.54",
+        "@authup/client-web-kit": "^1.0.0-beta.54",
         "chart.js": "^4.4.3",
         "@ilingo/validup": "^1.x",
         "@ilingo/validup-vue": "^1.x",

--- a/packages/mtb/package.json
+++ b/packages/mtb/package.json
@@ -29,7 +29,7 @@
         "lint": "eslint ."
     },
     "dependencies": {
-        "@authup/client-web-kit": "^1.0.0-beta.52",
+        "@authup/client-web-kit": "^1.0.0-beta.54",
         "@dnpm-dip/core": "^1.35.0",
         "@dnpm-dip/kit": "^1.28.1",
         "@nuxt/kit": "^4.4.5"

--- a/packages/portal/components/header.vue
+++ b/packages/portal/components/header.vue
@@ -109,7 +109,7 @@ export default defineNuxtComponent({
                                     href="javascript:void(0)"
                                     class="vc-nav-link"
                                 >
-                                    <span>{{ user.display_name ? user.display_name : user.name }}</span>
+                                    <span>{{ user.displayName ? user.displayName : user.name }}</span>
                                 </a>
                             </li>
                             <li class="vc-nav-item">

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -17,12 +17,12 @@
         "start": "node .output/server/index.mjs"
     },
     "devDependencies": {
-        "@authup/client-web-kit": "^1.0.0-beta.52",
-        "@authup/client-web-kit-theme": "^1.0.0-beta.52",
-        "@authup/client-web-nuxt": "^1.0.0-beta.52",
-        "@authup/core-http-kit": "^1.0.0-beta.52",
-        "@authup/core-kit": "^1.0.0-beta.52",
-        "@authup/kit": "^1.0.0-beta.52",
+        "@authup/client-web-kit": "^1.0.0-beta.54",
+        "@authup/client-web-kit-theme": "^1.0.0-beta.54",
+        "@authup/client-web-nuxt": "^1.0.0-beta.54",
+        "@authup/core-http-kit": "^1.0.0-beta.54",
+        "@authup/core-kit": "^1.0.0-beta.54",
+        "@authup/kit": "^1.0.0-beta.54",
         "@dnpm-dip/core": "^1.35.0",
         "@dnpm-dip/kit": "^1.28.1",
         "@dnpm-dip/mtb": "^1.35.0",

--- a/packages/rd/package.json
+++ b/packages/rd/package.json
@@ -28,7 +28,7 @@
         "lint": "eslint ."
     },
     "dependencies": {
-        "@authup/client-web-kit": "^1.0.0-beta.52",
+        "@authup/client-web-kit": "^1.0.0-beta.54",
         "@dnpm-dip/core": "^1.35.0",
         "@dnpm-dip/kit": "^1.28.1",
         "@nuxt/kit": "^4.4.5"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -49,7 +49,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@authup/client-web-kit-theme": "^1.0.0-beta.52",
+        "@authup/client-web-kit-theme": "^1.0.0-beta.54",
         "@vuecs/design": "^1.0.8",
         "@vuecs/theme-tailwind": "^6.1.1"
     },


### PR DESCRIPTION
Closes #1269.

Frontend-only migration mirroring the FLAME Hub rapiq v2 + `@authup` `1.0.0-beta.54` work (hub `3e59d8ccb`). The portal has no server/services and **no robot references**, so only the UI parts of the Hub migration apply.

## Changes

**Dependencies**
- All 15 `@authup/*` pins `beta.52` → `beta.54` (admin, core, mtb, rd, portal, theme).
- `rapiq@0.9` (only a *transitive* dep via `@authup/core-http-kit`) → `@rapiq/core@2.0.0-beta.7` in the tree.

**rapiq v2 (admin views)**
- `import type { BuildInput } from 'rapiq'` → query consts typed with authup's `EntityListQueryInput<T>` (from `@authup/client-web-kit`). Bare `QueryBuildInput<T>` (rapiq default depth 5) is **not** assignable to the depth-3-bounded `query` prop on `AClients`/`ARoles`/`AUsers`/`AIdentityProviders`/`AClientScopes` (TS2322), which is why the authup wrapper type is used (per issue §2).
- rapiq v2 query keys: `filter` → `filters`, and the dropped `include` alias → `relations`.

**authup beta.54 camelCase fields**
- `realm_id`→`realmId`, `display_name`→`displayName`, `client_id`→`clientId` (rapiq filter key), `built_in`→`builtIn`, `created_at`→`createdAt`, `updated_at`→`updatedAt` across admin views (VCTable column `key`s + `#cell-*` slots + row access) and the portal header (`user.display_name`→`user.displayName`).
- The OAuth2/PKCE `AuthorizationRequest` params in `login/index.vue` (`client_id`/`realm_id`/`redirect_uri`/`code_verifier`) correctly **stay snake_case** — verified against beta.54's type; they are wire params, not entity fields.
- `Client.is_confidential` (removed) → the clients table renders `authMethod` (`none|secret|tls`) as a chip instead of a boolean icon.

## Notes
- Issue §3 (strict typecheck) was already satisfied: portal build is `nuxt build && nuxt typecheck`, and it validates the admin/core source (portal aliases `@dnpm-dip/core`→`src` and loads modules from `../admin/src/module`).
- Robots removal and server/DB parts of the Hub migration are N/A for the portal.

## Validation
- `npm run build` — all 7 projects, including the portal's strict `nuxt typecheck`.
- ESLint clean on all changed files.
- Lockfile: cross-platform native-binding entries preserved (CI-safe).
- Not verified: live end-to-end rendering of the admin lists / auth-method column against a running authup backend (no backend/browser available in this environment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed client, identity provider, user, and role pages so realm filtering and assignments load correctly.
  - Corrected display names and creation/update timestamps across administrative tables and permission or role lists.
  - Updated the portal header to show authenticated users’ display names correctly.

- **Improvements**
  - Improved consistency and reliability of filtering and related data in administrative list views.
  - Updated supporting packages to maintain compatibility across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->