### PR TITLE
feat(portal): default the login flow to the admin-console client

### DIFF
--- a/packages/portal/nuxt.config.ts
+++ b/packages/portal/nuxt.config.ts
@@ -75,9 +75,11 @@ export default defineNuxtConfig({
             apiUrl: process.env.API_URL || 'https://dnpm-dip.net/api/',
             authupUrl: process.env.AUTHUP_URL || 'https://dnpm-dip.net/auth/',
             // OAuth2 client used for the authorization-code (PKCE) login flow.
-            // Defaults to Authup's built-in "web" client (CLIENT_WEB_NAME) at the
-            // call site; override per deployment. The client must register
-            // `<portal-origin>/login/callback` as an allowed redirect URI.
+            // Defaults to Authup's built-in "admin-console" system client at the
+            // call site; override per deployment (deployments on Authup
+            // <= v1.0.0-beta.58 set AUTHUP_CLIENT_ID=web). The portal origin
+            // must be listed in Authup's TRUSTED_ORIGINS so the redirect to
+            // `<portal-origin>/login/callback` is allowed.
             authupClientId: process.env.AUTHUP_CLIENT_ID,
             // Realm hint for resolving a name-identified client on `/authorize`
             // (Authup requires it). Accepts a realm UUID or name; defaults to

--- a/packages/portal/pages/login/index.vue
+++ b/packages/portal/pages/login/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { CLIENT_WEB_NAME, REALM_MASTER_NAME } from '@authup/core-kit';
+import { REALM_MASTER_NAME } from '@authup/core-kit';
 import {
     buildAuthorizeURL,
     createPKCE,
@@ -37,16 +37,21 @@ export default defineNuxtComponent({
         const apiClient = injectHTTPClient();
 
         // Configurable per deployment (AUTHUP_CLIENT_ID); defaults to the
-        // Authup built-in "web" client. The client must register
-        // `<portal-origin>/login/callback` as a redirect URI.
-        const clientId = (runtimeConfig.public.authupClientId as string) || CLIENT_WEB_NAME;
+        // Authup built-in "admin-console" system client (Authup releases after
+        // v1.0.0-beta.58 no longer provision the former shared "web" client;
+        // deployments still running an older Authup set AUTHUP_CLIENT_ID=web).
+        // The portal origin must be listed in Authup's TRUSTED_ORIGINS (or be
+        // the publicUrl origin) so `<portal-origin>/login/callback` is covered
+        // by the client's redirect allowlist.
+        const clientId = (runtimeConfig.public.authupClientId as string) || 'admin-console';
 
-        // A name-identified client (e.g. the built-in "web") is only resolvable
-        // with a realm hint — every realm ships its own "web" client, so Authup
-        // rejects the authorize request ("A realm is required to resolve a client
-        // by name.") without one. `realm_id` accepts a realm UUID or name; dnpm-dip
-        // runs a single (master) realm, so we default to REALM_MASTER_NAME and
-        // allow an override per deployment (AUTHUP_REALM_ID).
+        // A name-identified client (e.g. the built-in "admin-console") is only
+        // resolvable with a realm hint — every realm ships a client with that
+        // name, so Authup rejects the authorize request ("A realm is required
+        // to resolve a client by name.") without one. `realm_id` accepts a
+        // realm UUID or name; dnpm-dip runs a single (master) realm, so we
+        // default to REALM_MASTER_NAME and allow an override per deployment
+        // (AUTHUP_REALM_ID).
         const realmId = (runtimeConfig.public.authupRealmId as string) || REALM_MASTER_NAME;
 
         const busy = ref(false);


### PR DESCRIPTION
Authup releases after `v1.0.0-beta.58` no longer provision the shared per-realm `web` client the portal login defaulted to (authup/authup#3379). The built-in `admin-console` system client keeps existing in every realm and keeps deriving its redirect allowlist from `TRUSTED_ORIGINS`, so it becomes the portal's default for the single-realm (master) authorization-code flow.

- Deployments still running Authup `<= v1.0.0-beta.58` keep the old behavior by setting `AUTHUP_CLIENT_ID=web`; deploy this change together with (or after) the Authup upgrade.
- The portal origin must be listed in Authup's `TRUSTED_ORIGINS` (or be the `publicUrl` origin) so `<portal-origin>/login/callback` stays covered by the client's redirect allowlist — same requirement as before, unchanged.
- The `CLIENT_WEB_NAME` import is dropped alongside: the next `@authup/core-kit` release removes the constant, and the caret dependency range (`^1.0.0-beta.54`) would have pulled it in and broken the build.

Verified: `npm run build -w packages/portal` green with the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated portal authentication to use Authup’s built-in `admin-console` client by default.
  * Preserved support for legacy deployments configured with the `web` client.
  * Clarified redirect authorization requirements for portal origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->